### PR TITLE
Criteria, OSQL, DialectString, Expression - немножко фиксов

### DIFF
--- a/core/Base/IdentifiableObject.class.php
+++ b/core/Base/IdentifiableObject.class.php
@@ -17,7 +17,7 @@
 	 * @ingroup Base
 	 * @ingroup Module
 	**/
-	class /* spirit of */ IdentifiableObject implements Identifiable
+	class /* spirit of */ IdentifiableObject implements Identifiable, DialectString
 	{
 		protected $id = null;
 		
@@ -50,6 +50,11 @@
 			$this->id = $id;
 			
 			return $this;
+		}
+		
+		public function toDialectString(Dialect $dialect)
+		{
+			return $dialect->quoteValue($this->getId());
 		}
 	}
 ?>

--- a/core/Logic/Expression.class.php
+++ b/core/Logic/Expression.class.php
@@ -49,7 +49,7 @@
 		**/
 		public static function eqId($field, Identifiable $object)
 		{
-			return self::eq($field, $object->getId());
+			return self::eq($field, DBValue::create($object->getId()));
 		}
 		
 		/**

--- a/core/OSQL/SQLArray.class.php
+++ b/core/OSQL/SQLArray.class.php
@@ -43,8 +43,13 @@
 			if (is_array($array)) {
 				$quoted = array();
 				
-				foreach ($array as $item)
-					$quoted[] = $dialect->valueToString($item);
+				foreach ($array as $item) {
+					if ($item instanceof DialectString) {
+						$quoted[] = $item->toDialectString($dialect);
+					} else {
+						$quoted[] = $dialect->valueToString($item);
+					}
+				}
 				
 				$value = implode(', ', $quoted);
 			} else

--- a/main/DAOs/ProtoDAO.class.php
+++ b/main/DAOs/ProtoDAO.class.php
@@ -388,6 +388,7 @@
 			elseif (
 				($atom instanceof DBValue)
 				|| ($atom instanceof DBField)
+				|| ($atom instanceof DialectString)
 			) {
 				return $atom;
 			}

--- a/test/main/CriteriaTest.class.php
+++ b/test/main/CriteriaTest.class.php
@@ -164,6 +164,56 @@
 			);
 		}
 
+		public function testDialectStringObjects()
+		{
+			$criteria =
+				Criteria::create(TestUser::dao())->
+				setProjection(
+					Projection::property('id')
+				)->
+				add(
+					Expression::gt('registered', Date::create('2011-01-01'))
+				);
+			
+			$this->assertEquals(
+				$criteria->toDialectString(ImaginaryDialect::me()),
+				'SELECT test_user.id FROM test_user WHERE (test_user.registered > 2011-01-01)'
+			);
+			
+			$criteria =
+				Criteria::create(TestUserWithContactExtended::dao())->
+				setProjection(
+					Projection::property('contactExt.city.id', 'cityId')
+				)->
+				add(
+					Expression::eq('contactExt.city', TestCity::create()->setId(22))
+				);
+			
+			$this->assertEquals(
+				$criteria->toDialectString(ImaginaryDialect::me()),
+				'SELECT test_user_with_contact_extended.city_id AS cityId FROM test_user_with_contact_extended WHERE (test_user_with_contact_extended.city_id = 22)'
+			);
+			
+			$cityList = array(
+				TestCity::create()->setId(3),
+				TestCity::create()->setId(44),
+			);
+			
+			$criteria =
+				Criteria::create(TestUser::dao())->
+				setProjection(
+					Projection::property('id')
+				)->
+				add(
+					Expression::in('city', $cityList)
+				);
+			
+			$this->assertEquals(
+				$criteria->toDialectString(ImaginaryDialect::me()),
+				'SELECT test_user.id FROM test_user WHERE (test_user.city_id IN (3, 44))'
+			);
+		}
+
 		public static function orderDataProvider()
 		{
 			return array(


### PR DESCRIPTION
Привет. На работе неожиданно возник ряд вопросов:
1) почему в Criteria в Expression'ах нельзя работать с объектами, хотя в OSQL это позволяется, напимер: Expression::gt('registeredDate', Date::create('now'))
2) почему нельзя работать с IdentifiableObjects напрямую и не использовать сурогатную Expression::eqId. Т.е. тупо писать: Expression::eq('city', $city);
3) Тоже самое что и в пункте 2, но для IN выражений
4) Почему в Expression::eqId правое выражение не оборачивается в DBValue?

Неудержался и вечерком дома перед сном немножко покодил и предлагаю ряд фиксов:
1) Поддержка для критерия DialectString объектов - см. фикс в ProtoDAO
2) IdentifiableObject получает интерфейс DialectString и соответсвующий метод
3) SQLArray получает фикс, позволяющий работать с массивом объектов имеющих интерфейс DialectString
4) Ну и добавил в Criteria соответствующие тестики

Вопросы на повестке дня - может ли что либо из предложенного что-то сломать? И есть ли у кого либо возражения?
