### PR TITLE
DBBinary и PostgreSQL

### DIFF
--- a/core/DB/LiteDialect.class.php
+++ b/core/DB/LiteDialect.class.php
@@ -46,7 +46,7 @@
 		
 		public function quoteBinary($data)
 		{
-			return sqlite_udf_encode_binary($data);
+			return "'" .sqlite_udf_encode_binary($data)."'";
 		}
 		
 		public function unquoteBinary($data)

--- a/core/DB/PostgresDialect.class.php
+++ b/core/DB/PostgresDialect.class.php
@@ -74,7 +74,7 @@
 		
 		public function quoteBinary($data)
 		{
-			return pg_escape_bytea($data);
+			return "E'".pg_escape_bytea($data)."'";
 		}
 		
 		public function unquoteBinary($data)

--- a/core/OSQL/DBBinary.class.php
+++ b/core/OSQL/DBBinary.class.php
@@ -27,7 +27,7 @@
 		
 		public function toDialectString(Dialect $dialect)
 		{
-			return "'".$dialect->quoteBinary($this->getValue())."'";
+			return $dialect->quoteBinary($this->getValue());
 		}
 	}
 ?>

--- a/test/misc/DAOTest.class.php
+++ b/test/misc/DAOTest.class.php
@@ -626,11 +626,12 @@
 		public function nonIntegerIdentifier()
 		{
 			$id = 'non-integer-one';
+			$binaryData = "\0!bbq!\0";
 			
 			$bin =
 				TestBinaryStuff::create()->
 				setId($id)->
-				setData("\0!bbq!\0");
+				setData($binaryData);
 			
 			try {
 				TestBinaryStuff::dao()->import($bin);
@@ -645,13 +646,14 @@
 			$this->assertTrue($prm->import(array('id' => $id)));
 			$this->assertSame($prm->getValue()->getId(), $id);
 			
-			$this->assertEquals(TestBinaryStuff::dao()->getById($id), $bin);
+			$binLoaded = TestBinaryStuff::dao()->getById($id);
+			$this->assertEquals($binLoaded, $bin);
+			$this->assertEquals($binLoaded->getData(), $binaryData);
 			$this->assertEquals(TestBinaryStuff::dao()->dropById($id), 1);
 			
-			$id = Primitive::prototypedIdentifier('TestUser');
-			
+			$integerIdPrimitive = Primitive::prototypedIdentifier('TestUser');
 			try {
-				$id->import(array('id' => 'string-instead-of-integer'));
+				$integerIdPrimitive->import(array('id' => 'string-instead-of-integer'));
 			} catch (DatabaseException $e) {
 				return $this->fail();
 			}


### PR DESCRIPTION
При работе с binary колонками в таблице обратили внимание что Postgres ругается ворнингами, что они сохраняются в старом формате - Postgres хочет видеть буковку E перед 'бинарным текстом':
- http://www.postgresql.org/docs/8.0/static/datatype-binary.html - старая дока
- http://www.postgresql.org/docs/8.4/static/datatype-binary.html - новая дока

Залез посмотреть в код и увидел что у DBBinary и DBValue квотинг отличается кардинально. В value боковые кавычки ставятся прямо в методе quoteValue, а в binary кавычки ставятся именно в DBBinary. Это несколько не устраивает если хочется именно для постгреса сделать более особенное экранирование.

В общем это небольшая фантазия - как оно должно быть.

Не проверял - работает ли на старом постегресе, например 8.0.
