### PR TITLE
misc/Autoloader.inc.php & __autoload() - решение

### DIFF
--- a/misc/Autoloader.inc.php
+++ b/misc/Autoloader.inc.php
@@ -100,7 +100,7 @@
 					else {
 						// cache is not actual
 						$cache[ONPHP_CLASS_CACHE_CHECKSUM] = null;
-						__autoload($classname);
+						self::classPathCache($classname);
 					}
 				}
 			} else {


### PR DESCRIPTION
Проблема описаная @dovg в #30 присутствует. 

Раньше автозагрузка классов регистрировалась через функцию __autoload. В существующем коде осталось скорее всего по историческим причинам.

Предлагаю такой патч.
