### PR TITLE
Postgres: substring('foobar' from 2 for 3)

### DIFF
--- a/test/main/CriteriaTest.class.php
+++ b/test/main/CriteriaTest.class.php
@@ -214,6 +214,33 @@
 			);
 		}
 		
+		public function testSqlFunction()
+		{
+			$criteria =
+				Criteria::create(TestCity::dao())->
+				addProjection(
+					Projection::property(
+						SQLFunction::create(
+							'count',
+							SQLFunction::create(
+								'substring',
+								'name',
+								DBValue::create('M....w'),
+								DBValue::create('#')
+							)->
+							setJoiner('from')->
+							setJoiner('for', 1)
+						)
+						->setAggregateDistinct()
+					)
+				);
+			
+			$this->assertEquals(
+				$criteria->toDialectString(PostgresDialect::me()),
+				'SELECT count(DISTINCT substring("custom_table"."name" from \'M....w\' for \'#\')) FROM "custom_table"'
+			);
+		}
+		
 		public function testSleepWithEmptyDao()
 		{
 			$baseCriteria =
@@ -258,6 +285,8 @@
 				$this->fail();
 			} catch (WrongStateException $e) {/*it's good*/}
 		}
+		
+//		public function
 
 		public static function orderDataProvider()
 		{

--- a/test/main/OsqlSelectTest.class.php
+++ b/test/main/OsqlSelectTest.class.php
@@ -16,7 +16,16 @@
 					SQLFunction::create(
 						'count', DBField::create('field5', 'test_table')
 					)->
+					setAggregateDistinct()->
 					setAlias('alias5')
+				)->
+				get(
+					SQLFunction::create(
+						'substring',
+						DBField::create('field6', 'test_table'),
+						DBValue::create('a..b')
+					)->
+					setJoiner('from', 0)
 				);
 			
 			$this->assertEquals(
@@ -26,7 +35,8 @@
 					.'"test_table"."field2", '
 					.'"test_table"."field3" AS "alias3", '
 					.'"test_table"."field4", '
-					.'count("test_table"."field5") AS "alias5" '
+					.'count(DISTINCT "test_table"."field5") AS "alias5", '
+					.'substring("test_table"."field6" from \'a..b\') '
 				.'FROM "test_table"'
 			);
 		}


### PR DESCRIPTION
Сейчас нет возможности реализовать подобные функции через OSQL, но это порой требуется сделать.
Поэтому предлагаю фикс для SQLFunction где можно задавать 'склейщиков' между аргументами.

Реализация функции в заголовке будет выглядеть так:

``` php
<?php
SQLFunction::create(
    'substring',
    DBValue::create('foobar'),
    DBValue::create(2)->castTo('int'),
    DBValue::create(3)->castTo('int')
)->
setJoiner('from')->
setJoiner('for', 1)->
toDialectString(PostgresDialect::me());
```

Результат: `substring('foobar' from '2'::int for '3'::int)` который вернет в данном пример 'oob'

У кого какие есть предложения, замечания?
