### PR TITLE
Вычисление количества недель в году в соответствии с ISO 8601

### DIFF
--- a/core/Base/Date.class.php
+++ b/core/Base/Date.class.php
@@ -119,7 +119,7 @@
 		public static function getWeekCountInYear($year)
 		{
 			$weekCount = date('W', mktime(0, 0, 0, 12, 31, $year));
-			
+
 			if ($weekCount == '01') {
 				return date('W', mktime(0, 0, 0, 12, 24, $year));
 			} else {

--- a/test/core/DateTest.class.php
+++ b/test/core/DateTest.class.php
@@ -41,16 +41,9 @@
 			
 			$left = Timestamp::create('2008-03-29 03:00:00');
 			$right = Timestamp::create('2008-03-30 03:00:00');
-			
+
 			$this->dayDifferenceTest($left, $right, 1);
 
-			$weekCount = Date::getWeekCountInYear(2012);
-			$this->assertEquals($weekCount, 52, "Week count is incorrect");
-
-			$dateFromWeekNumberStamp = Date::makeFromWeek(5, 2012)->toStamp();
-			$expectedDate = Date::create('2012-01-30 00:00:00')->toStamp();
-			$this->assertEquals($dateFromWeekNumberStamp, $expectedDate, 'Creating date from week number is incorrect.');
-			
 			// unsolved giv's case
 			// $left = Timestamp::create('2008-10-25 03:00:00');
 			// $right = Timestamp::create('2008-10-26 02:59:00');
@@ -72,6 +65,38 @@
 			);
 			
 			return $this;
+		}
+
+		/**
+		 * @test
+		**/
+		public function testWeekCount()
+		{
+			$weekCount = Date::getWeekCountInYear(2012);
+			$this->assertEquals($weekCount, 52, "Week count is incorrect");
+
+			$dateFromWeekNumberStamp = Date::makeFromWeek(5, 2012)->toStamp();
+			$expectedDate = Date::create('2012-01-30 00:00:00')->toStamp();
+			$this->assertEquals($dateFromWeekNumberStamp, $expectedDate, 'Creating date from week number is incorrect.');
+
+			$weekCount2009 = Date::getWeekCountInYear(2009);
+			$expectedCount2009 = 53;
+			$this->assertEquals($weekCount2009, $expectedCount2009, 'Week count for 2009 year is incorrect.');
+
+			$weekBegin2009Stamp = Date::makeFromWeek(53, 2009)->toStamp();
+			$expectedDate2009 = Date::create('2009-12-28 00:00:00')->toStamp();
+			$this->assertEquals($weekBegin2009Stamp, $expectedDate2009, 'Week 53 for 2009 starts with incorrect date.');
+
+			$this->
+				assertEquals(
+					Date::makeFromWeek(1,2010)->toStamp(),
+					Date::create('2010-01-04')->toStamp(),
+					'Week 1 for 2010 starts with incorrect date.'
+				);
+
+			$this->assertEquals(Date::getWeekCountInYear(1996), 52, 'Incorrect week count in 1996 year');
+
+			$this->assertEquals(Date::getWeekCountInYear(1976), 53, 'Incorrect week count in 1976 year');
 		}
 
 		public function testMakeFromWeek()


### PR DESCRIPTION
Привет, коллеги.

Заметили, что при попытке создания даты из номера недели в 2012 году вываливается exception от assert'а. Всему виной то, что по стандарту ISO 8601 (вызов date('W', ...)) номер недели рассчитывается из того на какое число выпадает первый четверг года. Например, в 2012 году 1 января выпадает на воскресенье и на 52 неделю 2011 года! А вот 31 декабря 2012 года попадает на понедельник и на 1 неделю 2013 года, отсюда и assert.

Предлагаю следующие изменения.

Буду рад услышать ваши комментарии и предложения. Тесты насколько я вижу не сломал.
