### PR TITLE
Более подробное сообщение в MissingElementException для Enum, Enumeration and AbstractProtoClass

### DIFF
--- a/core/Base/Enum.class.php
+++ b/core/Base/Enum.class.php
@@ -49,7 +49,7 @@
 				$this->name = static::$names[$id];
 			} else
 				throw new MissingElementException(
-					'knows nothing about such id == '.$id
+					get_class($this) . ' knows nothing about such id == '.$id
 				);
 
 			return $this;

--- a/core/Base/Enumeration.class.php
+++ b/core/Base/Enumeration.class.php
@@ -92,7 +92,7 @@
 				$this->name = $names[$id];
 			} else
 				throw new MissingElementException(
-					'knows nothing about such id == '.$id
+					get_class($this) . ' knows nothing about such id == '.$id
 				);
 			
 			return $this;

--- a/main/Base/AbstractProtoClass.class.php
+++ b/main/Base/AbstractProtoClass.class.php
@@ -184,7 +184,7 @@
 				return $property;
 			
 			throw new MissingElementException(
-				"unknown property requested by name '{$name}'"
+				get_class($this) . ": unknown property requested by name '{$name}'"
 			);
 		}
 		


### PR DESCRIPTION
В случае бросания ошибки MissingElementException сразу указывается в каком классе ошибка произошла.
Если возражений не поступит, замержу после выходных в мастер и 1.0
