### PR TITLE
StorableDao: fix merging object with self

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,7 @@
+2012-05-31	Alexey S. Denisov
+
+	* main/DAOs/StorableDAO.class.php: fix merging object with self
+		
 2012-05-28	Georgiy T. Kutsurua
 
 	* core/Cache/PeclMemcache.class.php

--- a/main/DAOs/StorableDAO.class.php
+++ b/main/DAOs/StorableDAO.class.php
@@ -67,6 +67,8 @@
 				else
 					$old = Cache::worker($this)->getById($object->getId());
 			}
+			if ($object === $old)
+				return $this->save($object);
 			
 			return $this->unite($object, $old);
 		}


### PR DESCRIPTION
Во время очередного осмотра StorableDAO::merge попалась нестандартная ситуация когда в метод unite из метода merge передается объект для сравнения с самим собой. Думаю в таких случаях стоит вызывать в merge не unite, а save.
В общем предлагаю патч в две строчки. А в ближайшем будуйщем unite и merge ждут большие изменения.
Фикс пойдет в 1.1 и 1.0.
