### PR TITLE
CurlHttpClient: отправка файлов и массивы любой вложенности

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,10 @@
+2012-09-12	Alexey S. Denisov
+
+	* main/Flow/HttpRequest.class.php
+		main/Net/Http/CurlHttpClient.class.php
+		main/Utils/UrlParamsUtils.class.php:
+			allowing curlHttpClient upload files and send post/get arrays with any deep lvl
+
 2012-09-06	Igor V. Gulyaev
 
 	* main/Base/Hstore.class.php

--- a/doc/Migration1.0-1.1
+++ b/doc/Migration1.0-1.1
@@ -1,0 +1,1 @@
+https://github.com/onPHP/onphp-framework/wiki/Ru%3A1.0to1.1

--- a/global.inc.php.tpl
+++ b/global.inc.php.tpl
@@ -76,6 +76,12 @@
 			ONPHP_ROOT_PATH.'meta'.DIRECTORY_SEPARATOR
 		);
 	
+	/**
+	 * @deprecated 
+	 */
+	if (!defined('ONPHP_CURL_CLIENT_OLD_TO_STRING'))
+		define('ONPHP_CURL_CLIENT_OLD_TO_STRING', false);
+	
 	define('ONPHP_META_CLASSES', ONPHP_META_PATH.'classes'.DIRECTORY_SEPARATOR);
 	
 	define(

--- a/main/Flow/HttpRequest.class.php
+++ b/main/Flow/HttpRequest.class.php
@@ -29,7 +29,7 @@
 		// reference, not copy
 		private $session	= array();
 		
-		// uploads
+		// uploads and downloads (CurlHttpClient)
 		private $files		= array();
 		
 		// all other sh1t
@@ -37,9 +37,18 @@
 		
 		private $headers	= array();
 		
+		/**
+		 * @var HttpMethod
+		 */
 		private $method		= null;
 		
+		/**
+		 * @var HttpUrl
+		 */
 		private $url		= null;
+		
+		//for CurlHttpClient if you need to send raw CURLOPT_POSTFIELDS
+		private $body		= null;
 		
 		/**
 		 * @return HttpRequest
@@ -340,6 +349,26 @@
 		public function getUrl()
 		{
 			return $this->url;
+		}
+		
+		public function hasBody()
+		{
+			return $this->body !== null;
+		}
+		
+		public function getBody()
+		{
+			return $this->body;
+		}
+		
+		/**
+		 * @param string $body
+		 * @return HttpRequest
+		 */
+		public function setBody($body)
+		{
+			$this->body = $body;
+			return $this;
 		}
 	}
 ?>

--- a/main/Utils/UrlParamsUtils.class.php
+++ b/main/Utils/UrlParamsUtils.class.php
@@ -1,0 +1,79 @@
+<?php
+/***************************************************************************
+ *   Copyright (C) 2012 by Alexey S. Denisov                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License as        *
+ *   published by the Free Software Foundation; either version 3 of the    *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ ***************************************************************************/
+
+	/**
+	 * @ingroup Utils
+	**/
+	final class UrlParamsUtils extends StaticFactory
+	{
+		/**
+		 * @deprecated to support old convert method in CurlHttpClient
+		 * @param array $array
+		 * @return string 
+		 */
+		public static function toStringOneDeepLvl($array)
+		{
+			Assert::isArray($array);
+			$result = array();
+
+			foreach ($array as $key => $value) {
+				if (is_array($value)) {
+					foreach ($value as $valueKey => $simpleValue) {
+						$result[] =
+							$key.'['.$valueKey.']='.urlencode($simpleValue);
+					}
+				} else {
+					$result[] = $key.'='.urlencode($value);
+				}
+			}
+
+			return implode('&', $result);
+		}
+		
+		public static function toString($array)
+		{
+			$sum = function ($left, $right) {return $left.'='.urlencode($right);};
+			$params = self::toParamsList($array, true);
+			return implode('&',
+				array_map($sum, array_keys($params), $params)
+			);
+		}
+		
+		public static function toParamsList($array, $encodeKey = false)
+		{
+			$result = array();
+			
+			self::argumentsToParams($array, $result, '', $encodeKey);
+
+			return $result;
+		}
+
+		private static function argumentsToParams(
+			$array,
+			&$result,
+			$keyPrefix,
+			$encodeKey = false
+		) {
+			foreach ($array as $key => $value) {
+				$filteredKey = $encodeKey ? urlencode($key) : $key;
+				$fullKey = $keyPrefix
+					? ($keyPrefix.'['.$filteredKey.']')
+					: $filteredKey;
+				
+				if (is_array($value)) {
+					self::argumentsToParams($value, $result, $fullKey, $encodeKey);
+				} else {
+					$result[$fullKey] = $value;
+				}
+			}
+		}
+	}
+?>

--- a/test/config.inc.php.tpl
+++ b/test/config.inc.php.tpl
@@ -54,4 +54,5 @@
 	VoodooDaoWorker::setDefaultHandler('CacheSegmentHandler');
 	
 	define('__LOCAL_DEBUG__', true);
+	define('ONPHP_CURL_TEST_URL', 'http://localhost/curlTest.php'); //set here url to test script test/main/data/curlTest/curlTest.php
 ?>

--- a/test/main/Net/CurlHttpClientTest.class.php
+++ b/test/main/Net/CurlHttpClientTest.class.php
@@ -1,0 +1,194 @@
+<?php
+	final class CurlHttpClientTest extends TestCase
+	{
+		private static $failTestMsg = null;
+		private static $emptyMsg = null;
+		
+		public static function setUpBeforeClass() {
+			parent::setUpBeforeClass();
+			if (!defined('ONPHP_CURL_TEST_URL'))
+				self::$failTestMsg = 'not defined test constant ONPHP_CURL_TEST_URL';
+			
+			self::$emptyMsg = file_get_contents(ONPHP_CURL_TEST_URL);
+		}
+		
+		public function setUp() {
+			parent::setUp();
+			if (self::$failTestMsg)
+				$this->fail (self::$failTestMsg);
+			
+			$this->assertEquals(
+				$this->generateString(array(), array(), array(), ''),
+				self::$emptyMsg,
+				'wrong server empty response'
+			);
+		}
+		
+		public function testGetWithAdditionalGet()
+		{
+			$get = array(
+				'a' => array('b@&=' => array('c' => '@d@[]')),
+				'e' => array('f' => array('&1&', '3', '5')),
+			);
+			
+			$request = $this->spawnRequest(HttpMethod::get(), 'urlGet=really')->
+				setGet($get)->
+				setPost(array('post' => 'value'));
+			
+			$response = $this->spawnClient()->send($request);
+			
+			$this->assertEquals(
+				$this->generateString(array('urlGet' => 'really') + $get, array(), array(), ''),
+				$response->getBody()
+			);
+		}
+		
+		public function testPostAndFilesWithMultiCurl()
+		{
+			$get = array(
+				'get' => 'value',
+			);
+			$post1 = array(
+				'c' => array(
+					'd&=@' => '@',
+					'e' => array(
+						'f' => array('1' => '2'),
+						'g' => array('4' => '3'),
+					),
+					'k' => $this->getFile1Path(),
+				)
+			);
+			$post2 = array('post' => 'value');
+			$files = array(
+				'file1' => $this->getFile1Path(),
+				'file2' => $this->getFile2Path(),
+			);
+			$body = file_get_contents($this->getFile1Path());
+			
+			$request1 = $this->spawnRequest(HttpMethod::post(), 'urlGet=super')->
+				setGet($get)->
+				setPost($post1);
+			$request2 = $this->spawnRequest(HttpMethod::post())->
+				setPost($post2)->
+				setFiles($files);
+			$request3 = $this->spawnRequest(HttpMethod::post())->
+				setBody($body);
+			
+			$client = $this->spawnClient()->
+				addRequest($request1)->
+				addRequest($request2)->
+				addRequest($request3);
+			$client->multiSend();
+			
+			//check response 1st request
+			$this->assertEquals(
+				$this->generateString(array('urlGet' => 'super') + $get, $post1, array(), UrlParamsUtils::toString($post1)),
+				$client->getResponse($request1)->getBody()
+			);
+			
+			//check response 2nd request
+			$filesExpectation = array(
+				'file1' => file_get_contents($this->getFile1Path()),
+				'file2' => file_get_contents($this->getFile2Path()),
+			);
+			$this->assertEquals(
+				$this->generateString(array(), $post2, $filesExpectation, ''),
+				$client->getResponse($request2)->getBody()
+			);
+			
+			//check response 3rd request
+			$this->assertEquals(
+				$this->generateString(array(), array(), array(), $body),
+				$client->getResponse($request3)->getBody()
+			);
+		}
+		
+		public function testSecurityExceptionWithSendingFileAndAtInPost()
+		{
+			$post = array(
+				'a' => array(
+					array('b' => '@foobar')
+				)
+			);
+			
+			$files = array('file' => $this->getFile1Path());
+			
+			$request = $this->spawnRequest(HttpMethod::post())->
+				setPost($post)->
+				setFiles($files);
+			
+			try {
+				$this->spawnClient()->send($request);
+				$this->fail('expected NetworkException about security');
+			} catch (NetworkException $e) {
+				$this->assertStringStartsWith('Security excepion:', $e->getMessage());
+			}
+		}
+		
+		public function testSendingNotExistsFile()
+		{	
+			$files = array('file' => $this->getFileNotExists());
+			
+			$request = $this->spawnRequest(HttpMethod::post())->
+				setFiles($files);
+			
+			try {
+				$this->spawnClient()->send($request);
+				$this->fail('expected exception about not exists file');
+			} catch (WrongArgumentException $e) {
+				$this->assertStringStartsWith('couldn\'t access to file with path:', $e->getMessage());
+			}
+		}
+		
+		/**
+		 * @param HttpMethod $method
+		 * @return HttpRequest
+		 */
+		private function spawnRequest(HttpMethod $method, $urlPostfix = '')
+		{
+			$url = HttpUrl::create()->parse(ONPHP_CURL_TEST_URL);
+			$glue = $url->getQuery() ? '&' : '?';
+			
+			return HttpRequest::create()->
+				setUrl($url->parse(ONPHP_CURL_TEST_URL.$glue.$urlPostfix))->
+				setMethod($method);
+		}
+		
+		/**
+		 * @return CurlHttpClient
+		 */
+		private function spawnClient()
+		{
+			return CurlHttpClient::create()->
+				setOldUrlConstructor(false)->
+				setTimeout(5);
+		}
+		
+		private function generateString($get, $post, $files, $inputString)
+		{
+			ob_start();
+			var_dump($get, $post, $files, $inputString);
+			return ob_get_clean();
+		}
+		
+		private function getFile1Path()
+		{
+			return $this->getFileDirPath().'contents';
+		}
+		
+		private function getFile2Path()
+		{
+			return $this->getFileDirPath().'contents';
+		}
+		
+		private function getFileNotExists()
+		{
+			return $this->getFileDirPath().'notexists';
+		}
+		
+		private function getFileDirPath()
+		{
+			return ONPHP_TEST_PATH.'main/data/directory/';
+		}
+	}
+?>

--- a/test/main/Utils/UrlParamsUtilsTest.class.php
+++ b/test/main/Utils/UrlParamsUtilsTest.class.php
@@ -1,0 +1,57 @@
+<?php
+	final class UrlParamsUtilsTest extends TestCase
+	{
+		public function testOneDeepLvl()
+		{
+			$scope = array(
+				'a' => '1',
+				'c' => '@3',
+				'g' => array('1' => '1', '0' => '[0]'),
+			);
+			
+			$this->assertEquals(
+				'a=1&c=%403&g[1]=1&g[0]=%5B0%5D',
+				UrlParamsUtils::toStringOneDeepLvl($scope)
+			);
+			
+			$scope['z'] = array('2' => array('8' => '8'));
+			
+			try {
+				UrlParamsUtils::toStringOneDeepLvl($scope);
+				$this->fail('expected exception');
+			} catch (BaseException $e) {
+				$this->assertEquals(
+					'urlencode() expects parameter 1 to be string, array given',
+					$e->getMessage()
+				);
+			}
+		}
+		
+		public function testAnyDeepLvl()
+		{
+			$scope = array(
+				'foo' => array('foo' => array('foo' => '@bar')),
+				'bar' => array('@bar' => array('bar' => "foo[]я")),
+				'fo' => array(
+					array('o', 'ba', 'r'),
+				)
+			);
+			
+			$this->assertEquals(
+				array(
+					'foo[foo][foo]' => '@bar',
+					'bar[@bar][bar]' => 'foo[]я',
+					'fo[0][0]' => 'o',
+					'fo[0][1]' => 'ba',
+					'fo[0][2]' => 'r',
+				),
+				UrlParamsUtils::toParamsList($scope)
+			);
+			
+			$this->assertEquals(
+				'foo[foo][foo]=%40bar&bar[%40bar][bar]=foo%5B%5D%D1%8F&fo[0][0]=o&fo[0][1]=ba&fo[0][2]=r',
+				UrlParamsUtils::toString($scope)
+			);
+		}
+	}
+?>

--- a/test/main/data/curlTest/curlTest.php
+++ b/test/main/data/curlTest/curlTest.php
@@ -1,0 +1,12 @@
+<?php
+
+try {
+	$files = array();
+	foreach ($_FILES as $fileName => $value) {
+		if (isset($value['tmp_name']))
+			$files[$fileName] = file_get_contents($value['tmp_name']);
+	}
+	var_dump($_GET, $_POST, $files, file_get_contents('php://input'));
+} catch (Exception $e) {
+	var_dump(get_class($e), $e->getMessage(), $e->getCode(), $e->getFile(), $e->getLine(), $e->getTraceAsString());
+}


### PR DESCRIPTION
На работе поковыряли немножко CurlHttpClient и захотелось еще дополнительно дома его доковырять, что бы он умел делать все что нужно:

1) отправлять массивы любой вложенности:  

``` php
<?php
$request = HttpRequest::create()->setPost(array('a' => array('b' => array('c' => array(1, 2, 3))));
CurlHttpClient::create()->send($request);
```

В текущей версии вложенность для get и post ограничена двумерным массивом, однако более более глубокие массивы, возможно, кто-то получал заранее создавая массив вроде `array('a[b][c][0]' => '123')`. Теперь такие будет делать нельзя, т.к. теперь ключи массива прогоняются через urlencode так же как и значения.  

2) В случае HttpMethod::post предлагаю дополнять url параметрами из HttpRequest::getGet, так же как в случае HttpMethod::get  

3) Сделана загрузку файлов, их нужно задавать так:  

``` php
<?php
HttpRequest::create()->setFiles(array(
    'file1' => '/tmp/file1.txt',
    'pngFile' => '/tmp/someimage.pmg'
));
```

4) Добавлена возможность отправлять кастомное post тело (например, в некоторых случаях нужно отправлять post'ом xml файл):

``` php
<?php
HttpRequest::create()->setBody(
'<?xml version="1.0"?>
<!DOCTYPE metaconfiguration SYSTEM "meta.dtd">
<metaconfiguration><classes></classes></metaconfiguration>');
```

5) Т.к. изменена логика формирования post и get (добавлен urlencode для названия параметров), то реализовано возможность использовать старый алгоритм. Если нужно во всем проекте использовать старый алогоритм, то в конфиге объявить временную константу ONPHP_CURL_CLIENT_OLD_TO_STRING в true:  

``` php
<?php
define('ONPHP_CURL_CLIENT_OLD_TO_STRING', true);
```

В случае если нужно только в одном конкретном случае оставить старую логику формирования post/get параметров добавлена настройка в CurlHttpClient:

``` php
<?php
CurlHttpClient::create()->setOldUrlConstructor(true);
```
