### PR TITLE
Поддержка php 5.4 при генерации объектов

### DIFF
--- a/main/Utils/ClassUtils.class.php
+++ b/main/Utils/ClassUtils.class.php
@@ -223,6 +223,7 @@
 					if (
 						!class_exists($className)
 						&& !interface_exists($className)
+						&& !(function_exists('trait_exists') && trait_exists($className))
 					) {
 						include $file;
 					}


### PR DESCRIPTION
Если использовать php5.4 и trait'ы, то для генерации меты необходим подобный фикс. Вроде бы 5.3 и менее новые версии при этом не ломаются.
