### PR TITLE
PrimitiveHstore export должен возвращать массив а не объект.

### DIFF
--- a/core/Form/Primitives/PrimitiveHstore.class.php
+++ b/core/Form/Primitives/PrimitiveHstore.class.php
@@ -49,7 +49,10 @@
 		
 		public function getValue()
 		{
-			return $this->exportValue();
+			if (!$this->value instanceof Form)
+				return null;
+			
+			return Hstore::make($this->value->export());
 		}
 		
 		/**
@@ -103,7 +106,9 @@
 			if (!$this->value instanceof Form)
 				return null;
 			
-			return Hstore::make($this->value->export());
+			return !$this->value->getErrors()
+				? $this->value->export()
+				: null;
 		}
 		
 		/**

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,8 +1,12 @@
+2012-08-10	Alexey S. Denisov
+
+	* core/Form/Primitives/PrimitiveHstore.class.php:
+		PrimitiveHstore exportValue now return array|null instead Hstore object
+
 2012-08-08	Artem A. Naumenko
 
-	* core/DB/NoSQL/RedisNoSQL.class.php
-
-	added campability with old version of redis servers
+	* core/DB/NoSQL/RedisNoSQL.class.php:
+		added campability with old version of redis servers
 
 2012-07-20	Alexey S. Denisov
 

--- a/test/core/PrimitiveHstoreTest.class.php
+++ b/test/core/PrimitiveHstoreTest.class.php
@@ -1,6 +1,4 @@
 <?php
-	/* $Id$ */
-	
 	final class PrimitiveHstoreTest extends TestCase
 	{
 		protected static $scope =
@@ -47,6 +45,10 @@
 				$hstore->getList(),
 				self::$scope['properties']
 			);
+			$this->assertEquals(
+				$prm->exportValue(),
+				self::$scope['properties']
+			);
 			
 			try {
 				$hstore->get('NotFound');
@@ -80,6 +82,8 @@
 					'weight' => Form::WRONG
 				)
 			);
+			
+			$this->assertNull($prm->exportValue());
 			
 			$prm->clean();
 		}


### PR DESCRIPTION
Как-то раньше в глаза не бросалось, но PrimitiveHstore::export так же как и другие примитивы по логике должен возвращать то, что можно использовать для import'а - то есть ассоциативный массив.
Сейчас он возвращает Hstore объекты.
Предлагаю вот такой вот фикс, т.к. API ломается, то попасть оно должно только в мастер.
