### PR TITLE
Autoloader, class_exists, ClassNotFoundException

### DIFF
--- a/core/Form/Primitives/PrimitiveClass.class.php
+++ b/core/Form/Primitives/PrimitiveClass.class.php
@@ -51,7 +51,7 @@
 			Assert::isTrue(
 				class_exists($className, true)
 				|| interface_exists($className, true),
-				"knows nothing about '{$className}' class"
+				"knows nothing about '{$className}' class/interface"
 			);
 			
 			$this->ofClassName = $className;

--- a/global.inc.php.tpl
+++ b/global.inc.php.tpl
@@ -16,15 +16,6 @@
 		throw new BaseException($string, $code);
 	}
 	
-	/* void */ function __autoload_failed($classname, $message)
-	{
-		eval(
-			'if (!class_exists("ClassNotFoundException", false)) { '
-			.'final class ClassNotFoundException extends BaseException {/*_*/} }'
-			.'throw new ClassNotFoundException("'.$classname.': '.$message.'");'
-		);
-	}
-	
 	// file extensions
 	define('EXT_CLASS', '.class.php');
 	define('EXT_TPL', '.tpl.html');
@@ -53,6 +44,7 @@
 		.'Autoloader'.EXT_MOD;
 	
 	spl_autoload_register(array('Autoloader', ONPHP_CLASS_CACHE_TYPE), false);
+	Autoloader::registerClassNotFoundLoader();
 	
 	// system settings
 	error_reporting(E_ALL | E_STRICT);

--- a/test/core/PrimitiveClassTest.class.php
+++ b/test/core/PrimitiveClassTest.class.php
@@ -21,7 +21,7 @@
 			try {
 				$prm->of('InExIsNaNtClass');
 				$this->fail();
-			} catch (ClassNotFoundException $e) {
+			} catch (WrongArgumentException $e) {
 				// pass
 			}
 			


### PR DESCRIPTION
Давно в onPHP есть определенные проблемы с автолоадером на которые наталкиваешься при подключении автолоадеров других проектов и при проверке существования классов.
1. При использовании class_exists если класс не существует, то кидается ClassNotFoundException, хотя метод должен работать корректно и возвращать false
2. Невозможно в spl подключить другой автолоадер позже автолоадера из onPHP, т.к. он если не находит класс бросает ClassNotFoundException.

В предлагаемом варианте:
1. Вынесено бросание ClassNotFoundException в отдельную функцию для spl_autoload_register. Который в свою очередь бросает ClassNotFoundException в случае если вызов не был сделан через функции class_exists, interface_exists, trait_exists. Эта функция должна перезаписываться в конец стека автолоадеров, через вызов `Autoloader::registerClassNotFoundLoader();`
2. Основные функции для автолоадера теперь не вызывают функцию __autoload_failed и соответственно не бросают ClassNotFoundException.

Что при этом сломается:
1. Если кто-то оборачивал class_exists, inteface_exists, trait_exists try/catch/ClassNotFoundException - теперь такой ошибки бросаться не будет.
2. Если кто-то использовать Assert::classExists, то сейчас он бросает WrongArgumentException вместо ClassNotFoundException. Тут можно оставить что б бросался ClassNotFoundException. Не могу сказать как оно должно быть правильней.
