### PR TITLE
Исправление эскейпинга бинарных строк для Postgres 9.1+

### DIFF
--- a/core/DB/PostgresDialect.class.php
+++ b/core/DB/PostgresDialect.class.php
@@ -72,7 +72,16 @@
 		
 		public function quoteBinary($data)
 		{
-			return "E'".pg_escape_bytea($data)."'";
+			$esc = pg_escape_bytea($data);
+			if (mb_strpos($esc, '\\x') === 0) {
+				// http://www.postgresql.org/docs/9.1/static/datatype-binary.html
+				// if pg_escape_bytea use postgres 9.1+ it's return value like '\x00aabb' (new bytea hex format),
+				// but must return '\\x00aabb'. So we use this fix:'
+				return "E'\\".$esc."'";
+			} else {
+				//if function escape value like '\\000\\123' - all ok
+				return "E'".$esc."'";
+			}
 		}
 		
 		public function unquoteBinary($data)

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,5 +1,10 @@
 2012-08-10	Alexey S. Denisov
 
+	* core/DB/PostgresDialect.class.php:
+		fix incorrect bytea escaping for Postgres 9.1+
+
+2012-08-10	Alexey S. Denisov
+
 	* core/Form/Primitives/PrimitiveHstore.class.php:
 		PrimitiveHstore exportValue now return array|null instead Hstore object
 


### PR DESCRIPTION
Наткнулся на багу, что при эскейпинге бинарных строк в случае использования Postgres версии 9.1 - получается некорретное значение - нужно вручную приписывать к началу строки дополнительный слэш.
Дока по постгресу: http://www.postgresql.org/docs/9.1/static/datatype-binary.html
