### PR TITLE
GenericUri::parse сделать статическим

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,11 @@
 2012-09-12	Alexey S. Denisov
+	* main/Net/GenericUri.class.php
+		main/Net/HttpUrl.class.php
+		main/Net/Url.class.php
+		main/Net/Urn.class.php:
+			GenericUri::parse now static
+
+2012-09-12	Alexey S. Denisov
 
 	* main/Flow/HttpRequest.class.php
 		main/Net/Http/CurlHttpClient.class.php

--- a/main/Net/GenericUri.class.php
+++ b/main/Net/GenericUri.class.php
@@ -41,24 +41,22 @@
 		/**
 		 * @return GenericUri
 		**/
-		final public function parse($uri, $guessClass = false)
+		final public static function parse($uri, $guessClass = false)
 		{
-			$schemePattern = '([^:/?#]+):';
-			$authorityPattern = '(//([^/?#]*))';
-			$restPattern = '([^?#]*)(\?([^#]*))?(#(.*))?';
+			static $schemePattern = '([^:/?#]+):';
+			static $authorityPattern = '(//([^/?#]*))';
+			static $restPattern = '([^?#]*)(\?([^#]*))?(#(.*))?';
 			$matches = array();
 			
 			if (
 				$guessClass
-				&& ($knownSubSchemes = $this->getKnownSubSchemes())
+				&& ($knownSubSchemes = static::getKnownSubSchemes())
 				&& preg_match("~^{$schemePattern}~", $uri, $matches)
 				&& isset($knownSubSchemes[strtolower($matches[1])])
 			)
-				$class = $knownSubSchemes[strtolower($matches[1])];
+				$result = new $knownSubSchemes[strtolower($matches[1])];
 			else
-				$class = get_class($this);
-			
-			$result = new $class;
+				$result = new static;
 			
 			if ($result instanceof Url)
 				$pattern = "({$schemePattern}{$authorityPattern})?";
@@ -171,11 +169,11 @@
 			return $result;
 		}
 		
-		public function getKnownSubSchemes()
+		public static function getKnownSubSchemes()
 		{
 			return array_merge(
-				Urn::create()->getKnownSubSchemes(),
-				Url::create()->getKnownSubSchemes()
+				Urn::getKnownSubSchemes(),
+				Url::getKnownSubSchemes()
 			);
 		}
 		

--- a/main/Net/HttpUrl.class.php
+++ b/main/Net/HttpUrl.class.php
@@ -14,7 +14,7 @@
 	**/
 	final class HttpUrl extends Url
 	{
-		protected $knownSubSchemes	= array();
+		protected static $knownSubSchemes	= array();
 		
 		/**
 		 * @return HttpUrl

--- a/main/Net/Url.class.php
+++ b/main/Net/Url.class.php
@@ -17,7 +17,7 @@
 	**/
 	class Url extends GenericUri
 	{
-		protected $knownSubSchemes	= array(
+		protected static $knownSubSchemes	= array(
 			'http'		=> 'HttpUrl',
 			'https'		=> 'HttpUrl',
 			'ftp'		=> 'Url',
@@ -37,9 +37,9 @@
 			return new self;
 		}
 		
-		public function getKnownSubSchemes()
+		public static function getKnownSubSchemes()
 		{
-			return $this->knownSubSchemes;
+			return static::$knownSubSchemes;
 		}
 		
 		public function isValid()

--- a/main/Net/Urn.class.php
+++ b/main/Net/Urn.class.php
@@ -18,7 +18,7 @@
 	{
 		protected $schemeSpecificPart	= null;
 		
-		protected $knownSubSchemes	= array(
+		protected static $knownSubSchemes	= array(
 			'urn'		=> 'Urn',
 			'mailto'	=> 'Urn',
 			'news'		=> 'Urn',
@@ -35,9 +35,9 @@
 			return new self;
 		}
 		
-		public function getKnownSubSchemes()
+		public static function getKnownSubSchemes()
 		{
-			return $this->knownSubSchemes;
+			return static::$knownSubSchemes;
 		}
 		
 		public function isValid()

--- a/test/main/GenericUriTest.class.php
+++ b/test/main/GenericUriTest.class.php
@@ -3,7 +3,6 @@
  *   Copyright (C) 2007 by Ivan Khvostishkov                               *
  *   dedmajor@oemdesign.ru                                                 *
  ***************************************************************************/
-/* $Id$ */
 	
 	final class GenericUriTest extends TestCase
 	{
@@ -92,11 +91,9 @@
 				
 				if (!$parserClass)
 					$parserClass = 'GenericUri';
-					
-				$parser = new $parserClass;
 				
 				try {
-					$url = $parser->parse($testUrl, true);
+					$url = ClassUtils::callStaticMethod("$parserClass::parse", $testUrl, true);
 				} catch (WrongArgumentException $e) {
 					$exception = $e;
 				}


### PR DESCRIPTION
Случайно не сработал GenericUri::parse как ожидал, открыл - оказалось он создает и возвращает новый объект, а не модифицирует текущий, но при этом метод не статический. Видимо динамическим он был сделан из-за отсутствия позднего статического связывания. Сейчас его можно использовать.

Так же статическими становятся связанные с parse метод getKnownSubSchemes и свойство $knownSubSchemes у GenericUri и его наследников.

В тестах ничего не ломается, не меняется.
