### PR TITLE
Вызов Form::markCustom addCustomLabel одним методом

### DIFF
--- a/core/Form/Form.class.php
+++ b/core/Form/Form.class.php
@@ -120,9 +120,9 @@
 		/**
 		 * @return Form
 		**/
-		public function markMissing($primitiveName)
+		public function markMissing($primitiveName, $label = null)
 		{
-			return $this->markCustom($primitiveName, Form::MISSING);
+			return $this->markCustom($primitiveName, Form::MISSING, $label);
 		}
 		
 		/**
@@ -130,7 +130,7 @@
 		 * 
 		 * @return Form
 		**/
-		public function markWrong($name)
+		public function markWrong($name, $label = null)
 		{
 			if (isset($this->primitives[$name]))
 				$this->errors[$name] = self::WRONG;
@@ -140,6 +140,9 @@
 				throw new MissingElementException(
 					$name.' does not match known primitives or rules'
 				);
+			
+			if ($label !== null)
+				$this->addWrongLabel($name, $label);
 			
 			return $this;
 		}
@@ -166,11 +169,14 @@
 		 * 
 		 * @return Form
 		**/
-		public function markCustom($primitiveName, $customMark)
+		public function markCustom($primitiveName, $customMark, $label = null)
 		{
 			Assert::isInteger($customMark);
 			
 			$this->errors[$this->get($primitiveName)->getName()] = $customMark;
+			
+			if ($label !== null)
+				$this->addCustomLabel($primitiveName, $customMark, $label);
 			
 			return $this;
 		}

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,9 @@
+2012-09-26	Alexey S. Denisov
+
+	* core/Form/Form.class.php:
+		added to Form methods markMissing, markWrong, markCustom
+		optional argument "label" to set it without calling special method add*Label
+
 2012-09-19	Evgeny V. Kokovikhin
 
 	* main/Monitoring/PinbedMemcached.class.php: cosmetics


### PR DESCRIPTION
В очередной раз писал кастомные ошибки и надоело писать что-то вроде:

``` php5
$form->markCustom('id', 3);
$form->addCustomLabel('id', 3, 'here your custom error message');
```

Хочется добавить 3-ий не обязательный аргумент $label в метод markCustom и если он присутствует, то уж markCustom внутри и вызовет addCustomLabel, т.е. что бы снаружи выглядело вот так:

``` php5
$form->markCustom('id', 3, 'here your custom error message');
```

З.Ы. на github наконец пофиксили для php кода, что не надо писать открывающий php тэг, что бы код подсвечивался
