### PR TITLE
Корректный unquoting при использовании ValueObject

### DIFF
--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,3 +1,8 @@
+2012-12-23  Alexey S. Denisov
+	* main/Base/AbstractProtoClass.class.php
+		main/Base/InnerMetaProperty.class.php:
+			InnerMetaProperty (ValueObject) unquoting binary field fix
+
 2012-12-06  Evgeny V. Kokovikhin
 	* main/DAOs/GenericDAO.class.php 
 		meta/builders/AutoDaoBuilder.class.php 

--- a/main/Base/AbstractProtoClass.class.php
+++ b/main/Base/AbstractProtoClass.class.php
@@ -121,9 +121,9 @@
 			return $objectList;
 		}
 		
-		public static function makeOnlyObject($className, $array, $prefix = null)
+		public static function makeOnlyObject($className, $array, $prefix = null, ProtoDAO $parentDao = null)
 		{
-			return self::assemblyObject(new $className, $array, $prefix);
+			return self::assemblyObject(new $className, $array, $prefix, $parentDao);
 		}
 		
 		public static function completeObject(Prototyped $object)
@@ -383,13 +383,13 @@
 		}
 		
 		private static function assemblyObject(
-			Prototyped $object, $array, $prefix = null
+			Prototyped $object, $array, $prefix = null, ProtoDAO $parentDao = null
 		)
 		{
 			if ($object instanceof DAOConnected)
 				$dao = $object->dao();
 			else
-				$dao = null;
+				$dao = $parentDao ?: null;
 			
 			$proto = $object->proto();
 			

--- a/main/Base/InnerMetaProperty.class.php
+++ b/main/Base/InnerMetaProperty.class.php
@@ -75,7 +75,7 @@
 			
 			return $proto->completeObject(
 				$proto->makeOnlyObject(
-					$this->getClassName(), $array, $prefix
+					$this->getClassName(), $array, $prefix, $dao
 				),
 				$array,
 				$prefix


### PR DESCRIPTION
Давно давно наткнулся на багу, исправил, но PullRequest не до сих пор не оформил/
Если в ValueObject хранить тип binary, то при получении объекта с этим ValueObject из базы, вываливается фатал из-за того что в нужном месте не оказывается DAO родителя (у самого ValueObject нет своего DAO), у которого нужно получить диалект и вызвать метод unquoteBinary.

Решение: при сборке ValueObject'ов надо в proto передавать родительский DAO класс и Proto класса у которого нет своего DAO будет использовать родительский.
