### PR TITLE
null по умолчанию для необязательных атрибутов в Auto classes

### DIFF
--- a/meta/types/ObjectType.class.php
+++ b/meta/types/ObjectType.class.php
@@ -239,7 +239,7 @@ public function {$methodName}({$this->className} \${$name}{$defaultValue})
 /**
  * @return {$property->getClass()->getName()}
 **/
-public function {$methodName}Id(\$id)
+public function {$methodName}Id(\$id{$defaultValue})
 {
 	\$this->{$name} = null;
 	\$this->{$name}Id = \$id;


### PR DESCRIPTION
Если в meta некий атрибут имеет required = false, то было бы логичнее разрешить в сеттере null в качестве возможного значения:

``` diff
-       public function setLanguage(UserLanguage $language)
+       public function setLanguage(UserLanguage $language = null)
```

К примеру, код, синхронизирующий язык двух пользователей, можно будет переписать с

``` php
if ($user1->getLanguage())
    $user2->setLanguage($user1->getLanguage());
```

на

``` php
$user2->setLanguage($user1->getLanguage());
```
