### PR TITLE
PrimitiveIdentifier: работа с классом не по id

### DIFF
--- a/core/Form/Primitives/IdentifiablePrimitive.class.php
+++ b/core/Form/Primitives/IdentifiablePrimitive.class.php
@@ -16,6 +16,7 @@
 		extends PrimitiveInteger // parent class doesn't really matter here
 	{
 		protected $className = null;
+		private $extractMethod = 'getId';
 		
 		/**
 		 * due to historical reasons, by default we're dealing only with
@@ -24,6 +25,29 @@
 		protected $scalar = false;
 		
 		abstract public function of($className);
+		
+		/**
+		 * @param mixed $extractMethod
+		 * @return IdentifiablePrimitive
+		 */
+		public function setExtractMethod($extractMethod)
+		{
+			if (is_callable($extractMethod)) {
+				/* all ok, call what you want */
+			} elseif (strpos($extractMethod, '::') === false) {
+				Assert::isTrue(
+					method_exists($this->className, $extractMethod),
+					"knows nothing about '".$this->className
+					."::{$extractMethod}' method"
+				);
+			} else {
+				ClassUtils::checkStaticMethod($extractMethod);
+			}
+			
+			$this->extractMethod = $extractMethod;
+			
+			return $this;
+		}
 		
 		/**
 		 * @return string
@@ -77,7 +101,7 @@
 			if (!$this->value)
 				return null;
 			
-			return $this->value->getId();
+			return $this->actualExportValue($this->value);
 		}
 		
 		/* void */ protected function checkNumber($number)
@@ -94,6 +118,21 @@
 				return (int) $number;
 			
 			return $number;
+		}
+		
+		protected function actualExportValue($value)
+		{
+			if (!ClassUtils::isInstanceOf($value, $this->className)) {
+				return null;
+			}
+			
+			if (is_callable($this->extractMethod)) {
+				return call_user_func($this->extractMethod, $value);
+			} elseif (strpos($this->extractMethod, '::') === false) {
+				return $value->{$this->extractMethod}($value);
+			} else {
+				ClassUtils::callStaticMethod($this->extractMethod, $value);
+			}
 		}
 	}
 ?>

--- a/doc/ChangeLog
+++ b/doc/ChangeLog
@@ -1,4 +1,11 @@
+2012-11-25  Nikita V. Konstantinov
+
+	* core/Form/Primitives/PrimitiveIdentifier.class.php
+		core/Form/Primitives/PrimitiveIdentifier.class.php:
+			PrimitiveIdentifier now can export/import objects by custom methods
+
 2012-11-18  Nikita V. Konstantinov
+
 	* meta/types/ObjectType.class.php:
 		update for Business objects - now you can setSomeProperty(null)
 		for Objects properties if it's not required

--- a/test/core/PrimitiveIdentifierTest.class.php
+++ b/test/core/PrimitiveIdentifierTest.class.php
@@ -1,7 +1,7 @@
 <?php
 	/* $Id$ */
 	
-	final class PrimitiveIdentifierTest extends TestCase
+	final class PrimitiveIdentifierTest extends TestCaseDAO
 	{
 		public function testEmpty()
 		{
@@ -19,6 +19,67 @@
 				$this->assertFalse($prm->import(array('name' => $value)));
 				$this->assertFalse($prm->importValue($value));
 			}
+		}
+		
+		/**
+		 * @group pi
+		 */
+		public function testCustomImportExport()
+		{
+			$dbs = DBTestPool::me()->getPool();
+			if (empty($dbs)) {
+				$this->fail('For test required at least one DB in config');
+			}
+			DBPool::me()->setDefault(reset($dbs));
+			
+			$moscow = TestCity::create()->setCapital(true)->setName('Moscow');
+			$moscow->dao()->add($moscow);
+
+			$stalingrad = TestCity::create()->setCapital(false)->setName('Stalingrad');
+			$stalingrad->dao()->add($stalingrad);
+
+			$prms = array();
+			$prms[] = Primitive::identifier('city')->
+				setScalar(true)->
+				of('TestCity')->
+				setMethodName('PrimitiveIdentifierTest::getCityByName')->
+				setExtractMethod('PrimitiveIdentifierTest::getCityName');
+			
+			$prms[] = Primitive::identifier('city')->
+				setScalar(true)->
+				of('TestCity')->
+				setMethodName(array(get_class($this), 'getCityByName'))->
+				setExtractMethod(function(TestCity $city) {return $city->getName();});
+			
+			foreach ($prms as $prm) {
+				$prm->import(array('city' => 'Moscow'));
+				$this->assertEquals($moscow, $prm->getValue());
+				$this->assertEquals('Moscow', $prm->exportValue());
+
+				$prm->importValue($stalingrad);
+				$this->assertequals($stalingrad, $prm->getValue());
+				$this->assertequals('Stalingrad', $prm->exportValue());
+
+				$prm->import(array('city' => $moscow));
+				$this->assertEquals($moscow, $prm->getValue());
+				$this->assertEquals('Moscow', $prm->exportValue());
+			}
+		}
+		
+		/**
+		 * @param string $name
+		 * @return TestCity
+		 */
+		public static function getCityByName($name)
+		{
+			return Criteria::create(TestCity::dao())->
+				add(Expression::eq('name', DBValue::create($name)))->
+				get();
+		}
+		
+		public static function getCityName(TestCity $city)
+		{
+			return $city->getName();
 		}
 	}
 ?>


### PR DESCRIPTION
В очередной редкий раз нужно было получать объект не по id, а по другому его уникальному полю. Посмотрел PrimitiveIdentifier и решил чуть допилить его что бы можно было делать так:

``` php
Primitive::identifier('city')
    ->setScalar(true)
    ->of('TestCity')
    ->setMethodName('getCityByName') //daoobject method name
    ->setExtractMethod('PrimitiveIdentifierTest::getCityName'); //static method signature
```

или, например, так

``` php
$getByName = function($value) {
    return Criteria::create(TestCity::dao())
        ->add(Expression::eq('name', DBValue::create($value))
        ->get();
};

Primitive::identifier('city')
    ->setScalar(true)
    ->of('TestCity')
    ->setMethodName($getByName) //any is_callable variable
    ->setExtractMethod('getName'); //business object methodname 
```
