### PR TITLE
strange actual value

### DIFF
--- a/core/Form/Primitives/BasePrimitive.class.php
+++ b/core/Form/Primitives/BasePrimitive.class.php
@@ -72,22 +72,34 @@
 		{
 			return $this->raw;
 		}
+
+		public function getValueOrDefault()
+		{
+			if ($this->value !== null)
+				return $this->value;
+
+			return $this->default;
+		}
 		
+		/**
+		 * @deprecated since version 1.0
+		 * @see getSafeValue, getValueOrDefault
+		 */
 		public function getActualValue()
 		{
-			if (null !== $this->value)
+			if ($this->value !== null)
 				return $this->value;
 			elseif ($this->imported)
 				return $this->raw;
 			
 			return $this->default;
 		}
-		
+
 		public function getSafeValue()
 		{
 			if ($this->imported)
 				return $this->value;
-			
+
 			return $this->default;
 		}
 		

--- a/core/Form/Primitives/PrimitiveAlias.class.php
+++ b/core/Form/Primitives/PrimitiveAlias.class.php
@@ -57,25 +57,24 @@
 			return $this->primitive->getRawValue();
 		}
 		
+
+		public function getValueOrDefault()
+		{
+			return $this->primitive->getValueOrDefault();
+		}
+
 		/**
 		 * @deprecated by getFormValue
+		 * since version 1.0 by getValueOrDefault
 		**/
 		public function getActualValue()
 		{
-			if (null !== $this->primitive->getValue())
-				return $this->primitive->getValue();
-			elseif ($this->primitive->isImported())
-				return $this->primitive->getRawValue();
-			
-			return $this->primitive->getDefault();
+			return $this->primitive->getActualValue();
 		}
 		
 		public function getSafeValue()
 		{
-			if ($this->primitive->isImported())
-				return $this->primitive->getValue();
-			
-			return $this->primitive->getDefault();
+			return $this->primitive->getSafeValue();
 		}
 		
 		public function getFormValue()

--- a/core/Form/Primitives/TimeList.class.php
+++ b/core/Form/Primitives/TimeList.class.php
@@ -53,17 +53,30 @@
 			
 			return ($this->value !== array());
 		}
-		
+
+		public function getValueOrDefault()
+		{
+			if (is_array($this->value) && $this->value[0])
+				return $this->value;
+
+			return array($this->default);
+		}
+
+		/**
+		 * @deprecated deprecated since version 1.0
+		 * @see getSafeValue, getValueOrDefault
+		 * @return type
+		 */
 		public function getActualValue()
 		{
 			if (is_array($this->value) && $this->value[0])
 				return $this->value;
 			elseif (is_array($this->raw) && $this->raw[0])
 				return $this->raw;
-			
+
 			return array($this->default);
 		}
-		
+
 		public static function stringToTimeList($string)
 		{
 			$list = array();


### PR DESCRIPTION
Метод getActualVal взвращает raw (!) импорт был, но не удался.
Может я чегойта не понимаю, но если я в форме впишу

```
$form =
    Form::create()->
        add(
            Primitive::integer('limit')->
            setDefault(20)->
            setMin(10)->setMax(50)
        )->
        import(array('limit' => 10000));  // или "йа строка"

$this->result =
    Criteria::create(Person::dao())->
        setLimit($form->getActualValue('limit'))->
        getList();
```

получу 10000, но вот почему-то я ожидал получить 20 пользователей.

Причем getSafeValue вернет null.
Тесты не запускал, ибо не пользуюсь ими пока (не дорос), но код тестов просмотрел и ничего полезного там не нашел.
В onphp-ucheba это выпилино окло года назад (недо-beta 0.1), а до новой версии на днях добрался. =)
