### PR TITLE
Поддержка travis continiouse integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: php
+php:
+  - "5.3"
+
+
+services:
+  - mysql
+  - postgresql
+  - rabbitmq
+  - memcached
+  - redis-server
+
+
+before_install:
+ - sudo apt-get update -qq
+ - sudo apt-get install -qq memcached php5-memcache php5-memcached
+
+
+before_script:
+  - ./.travis/install_pecl_extensions.sh
+  - psql -c "DROP DATABASE IF EXISTS onphp;" -U postgres
+  - psql -c 'create database onphp;' -U postgres
+  - mysql -e "create database IF NOT EXISTS onphp;" -uroot;
+
+
+script: ./test/runme.sh

--- a/.travis/install_pecl_extensions.sh
+++ b/.travis/install_pecl_extensions.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+PHP_INI_PATH=$(php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||")
+
+echo "Loaded php.ini path: "$PHP_INI_PATH
+
+#echo "Install pecl memcache"
+#printf "\n" | pecl install memcache
+#wget http://pecl.php.net/get/memcache-2.2.7.tgz
+#tar -xzf memcache-2.2.7.tgz
+#sh -c "cd memcache-2.2.7 && phpize && ./configure --enable-memcache && make && sudo make install"
+#echo "extension=memcache.so" >> $PHP_INI_PATH
+
+#echo "Install pecl memcached"
+#printf "\n" | pecl install memcached
+#wget http://pecl.php.net/get/memcached-2.1.0.tgz
+#tar -xzf memcached-2.1.0.tgz
+#sh -c "cd memcached-2.1.0 && phpize && ./configure --enable-memcached && make && sudo make install"
+#echo "extension=memcached.so" >> $PHP_INI_PATH

--- a/test/config.inc.php.tpl
+++ b/test/config.inc.php.tpl
@@ -2,22 +2,22 @@
 	
 	$dbs = array(
 		'PgSQL' => array(
-			'user'	=> 'onphp',
-			'pass'	=> 'onphp',
+			'user'	=> 'postgres',
+			'pass'	=> '',
 			'host'	=> '127.0.0.1',
 			'base'	=> 'onphp'
 		),
 		'MySQL' => array(
-			'user'	=> 'onphp',
-			'pass'	=> 'onphp',
+			'user'	=> 'root',
+			'pass'	=> '',
 			'host'	=> '127.0.0.1',
 			'base'	=> 'onphp'
 		),
 		'SQLitePDO' => array(
-			'user'	=> 'onphp',
-			'pass'	=> 'onphp',
+			'user'	=> '',
+			'pass'	=> '',
 			'host'	=> '127.0.0.1',
-			'base'	=> 'onphp'
+			'base'	=> ':memory:'
 		),
 	);
 
@@ -25,9 +25,9 @@
 		'NullDaoWorker', 'CommonDaoWorker', 'SmartDaoWorker', 'VoodooDaoWorker',
 		'CacheDaoWorker', 'VoodooDaoWorker', 'SmartDaoWorker', 'CommonDaoWorker', 'NullDaoWorker'
 	);
-	
+
 	VoodooDaoWorker::setDefaultHandler('CacheSegmentHandler');
-	
+
 	define('__LOCAL_DEBUG__', true);
 	define('ONPHP_CURL_TEST_URL', 'http://localhost/curlTest.php'); //set here url to test script test/main/data/curlTest/curlTest.php
 ?>

--- a/test/runme.sh
+++ b/test/runme.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 cd `dirname $0`
 
 if [ "$*" = '' ]


### PR DESCRIPTION
Сосбственно как и обещал добавил поддежку travis серверов для прогона наших unit тестов в облаке.

В этой итерации я пока научил травис только гонять тесты, далее может добавим phplint для проверки Coding Stye

Базы:
- Postgres
- MySQL
- SQLite3

Cache:
- Memcache
- Redis

Менеджер очередей:
- RabbitMQ

По всем этим сервисам успешно гоняются тесты :)

Что такое Travis ?
Это сервис облачного хостинга где можно запускать и гонять практически любой код, грубо гоовря виртуальный сервер с установленной ubuntu :)

Зачем нам это ?
А это очень хороший инструсент всем участникам смотреть результаты тестов прогоняемых на серверах Travis

Как это работает ?
При коммите в репозиторий этот коммит подсасывается Travisom автоматом и на эти изменения Travis  пытается прогнать все тесты, сообщая о результатах в лог вывода

Где можно на это посмотреть ?
Ну можно тут https://travis-ci.org а вообще лучше все-же ознакомится с докой http://about.travis-ci.org/docs/
Еще у гитхаба есть нативная интеграция с Travis-ом, те результаты теста по последнему коммиту вы всегда сможете посмотреть  рядом с кнопкой автомержа у пул реквеста

Вопросы?
Предложения?
