### PR TITLE
identifiable::wrap uses "static"

### DIFF
--- a/core/Base/IdentifiableObject.class.php
+++ b/core/Base/IdentifiableObject.class.php
@@ -11,26 +11,26 @@
 
 	/**
 	 * Ideal Identifiable interface implementation. ;-)
-	 * 
+	 *
 	 * @see Identifiable
-	 * 
+	 *
 	 * @ingroup Base
 	 * @ingroup Module
 	**/
 	class /* spirit of */ IdentifiableObject implements Identifiable, DialectString
 	{
 		protected $id = null;
-		
+
 		/**
 		 * @return IdentifiableObject
 		**/
 		public static function wrap($id)
 		{
-			$io = new self;
-			
+			$io = new static;
+
 			return $io->setId($id);
 		}
-		
+
 		public function getId()
 		{
 			if (
@@ -41,20 +41,19 @@
 			else
 				return $this->id;
 		}
-		
+
 		/**
 		 * @return IdentifiableObject
 		**/
 		public function setId($id)
 		{
 			$this->id = $id;
-			
+
 			return $this;
 		}
-		
+
 		public function toDialectString(Dialect $dialect)
 		{
 			return $dialect->quoteValue($this->getId());
 		}
 	}
-?>

--- a/core/Base/NamedObject.class.php
+++ b/core/Base/NamedObject.class.php
@@ -11,41 +11,40 @@
 
 	/**
 	 * @see Named
-	 * 
+	 *
 	 * @ingroup Base
 	 * @ingroup Module
 	**/
-	abstract class NamedObject
+	class NamedObject
 		extends IdentifiableObject
 		implements Named, Stringable
 	{
 		protected $name	= null;
-		
+
 		public static function compareNames(
 			Named $left, Named $right
 		)
 		{
 			return strcasecmp($left->getName(), $right->getName());
 		}
-		
+
 		public function getName()
 		{
 			return $this->name;
 		}
-		
+
 		/**
 		 * @return NamedObject
 		**/
 		public function setName($name)
 		{
 			$this->name = $name;
-			
+
 			return $this;
 		}
-		
+
 		public function toString()
 		{
 			return "[{$this->id}] {$this->name}";
 		}
 	}
-?>


### PR DESCRIPTION
Раз уж метод wrap наследуется, то и оборачивать должен в наследника используя позднее связывание. Доступно с 5.3.0. 
NamedObject не справедливо объявлен абстрактным. Самодостаточен (не имеет абстракных методов) и может (будучи не абстрактным) быть использован как обертка для $key $val.
