### PR TITLE
PrimitiveRule, изменение внутренностей Form::addRule, checkRules и т.д.

### DIFF
--- a/core/Form/Primitive.class.php
+++ b/core/Form/Primitive.class.php
@@ -394,5 +394,10 @@
 		{
 			return new PrimitiveEnumList($name);
 		}
+		
+		public static function rule($name)
+		{
+			return new PrimitiveRule($name);
+		}
 	}
 ?>

--- a/core/Form/Primitives/PrimitiveRule.class.php
+++ b/core/Form/Primitives/PrimitiveRule.class.php
@@ -1,0 +1,45 @@
+<?php
+/***************************************************************************
+ *   Copyright (C) 2008 by Konstantin V. Arkhipov                          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License as        *
+ *   published by the Free Software Foundation; either version 3 of the    *
+ *   License, or (at your option) any later version.                       *
+ *                                                                         *
+ ***************************************************************************/
+
+	/**
+	 * @ingroup Primitives
+	**/
+	final class PrimitiveRule extends BasePrimitive
+	{
+		/**
+		 * @var LogicalObject
+		 */
+		private $expression	= null;
+
+		public function __clone()
+		{
+			$this->expression = clone $this->expression;
+		}
+
+		/**
+		 * @return PrimitiveRule
+		**/
+		public function setExpression(LogicalObject $exp)
+		{
+			$this->expression = $exp;
+
+			return $this;
+		}
+
+		public function import($scope, Form $form = null)
+		{
+			Assert::isNotNull($form, 'expects Form as 2-nd argument');
+			Assert::isNotNull($this->expression, 'setExpression first');
+
+			return $this->expression->toBoolean($form) === true;
+		}
+	}
+?>

--- a/core/Form/RegulatedForm.class.php
+++ b/core/Form/RegulatedForm.class.php
@@ -17,9 +17,6 @@
 	**/
 	abstract class RegulatedForm extends PlainForm
 	{
-		protected $rules		= array(); // forever
-		protected $violated		= array(); // rules
-		
 		/**
 		 * @throws WrongArgumentException
 		 * @return Form
@@ -28,9 +25,9 @@
 		{
 			Assert::isString($name);
 			
-			$this->rules[$name] = $rule;
-			
-			return $this;
+			return $this->add(
+				Primitive::rule($name)->setExpression($rule)
+			);
 		}
 		
 		/**
@@ -39,32 +36,17 @@
 		**/
 		public function dropRuleByName($name)
 		{
-			if (isset($this->rules[$name])) {
-				unset($this->rules[$name]);
-				return $this;
+			$rule = $this->get($name);
+			if (!$rule instanceof PrimitiveRule) {
+				throw new MissingElementException("no such PrimitiveRule with '{$name}' name");
 			}
-			
-			throw new MissingElementException(
-				"no such rule with '{$name}' name"
-			);
+			return $this->drop($name);
 		}
 		
 		public function ruleExists($name)
 		{
-			return isset($this->rules[$name]);
-		}
-		
-		/**
-		 * @return Form
-		**/
-		public function checkRules()
-		{
-			foreach ($this->rules as $name => $logicalObject) {
-				if (!$logicalObject->toBoolean($this))
-					$this->violated[$name] = Form::WRONG;
-			}
-			
-			return $this;
+			return $this->primitiveExists($name)
+				&& $this->get($name) instanceof PrimitiveRule;
 		}
 	}
 ?>


### PR DESCRIPTION
PrimitiveRule, вырезанный из #101. Оно мне понравилось и хочется заюзать. 
<liric>
Лирическое отступление. Решил вырезать его оттуда т. к. все вместе выглядит большим и пугающим, а добровольцы желающие его дописать пока еще [не разобрались как дружить с тестами](https://github.com/onPHP/onphp-framework/pull/168), и не сильно загорелись желанием разделять код на части.
<liric>

Идея следующая
- Убираем из формы отдельный массив rule
- Делаем класс PrimitiveRule который болтается взамен в общем списке примитивов у формы, делаем что б валидировал Form'у через метод import
- не даём ему импортиться при вызовах Form::import\* 
- но импортим его при вызове Form::checkRules
- API расширяется, BC сохраняется
- Методы Form::addRule($name, $expression) остаются т. к. порой удобней использовать их
- Из изначальной задумки убрано свойство PrimitiveRule->form и соответственно метод PrimitiveRule::setForm, взамен них примитив ожидает что при импорте вторым аргументом будет передана форма.
- на всё про всё ушло:
  - час с небольшим на вырезание нужного кода из #101, 
  - еще 20 минут на тестирование и осмотр тестов (их не дописывал, т. к. [они были написаны раньше](https://github.com/onPHP/onphp-framework/blame/master/test/core/FormTest.class.php#L70) на пару опечаток с ними поправил) 
  - еще 20 минут на написание реквеста
