### PR TITLE
Eval is evil (singleton)

### DIFF
--- a/core/Base/Singleton.class.php
+++ b/core/Base/Singleton.class.php
@@ -31,13 +31,17 @@
 				if (2 < func_num_args()) {
 					$args = func_get_args();
 					array_shift($args);
-					
-					// can't call protected constructor through reflection
-					eval(
-						'$object = new '.$class
-						.'($args['.implode('],$args[', array_keys($args)).']);'
+
+					// emulation of ReflectionClass->newInstanceWithoutConstructor
+					$object =
+						unserialize(
+							sprintf('O:%d:"%s":0:{}', strlen($class), $class)
+						);
+
+					call_user_func_array(
+						array($object, '__construct'),
+						$args
 					);
-				
 				} else {
 					$object =
 						$args


### PR DESCRIPTION
В данном PR предлагается избавиться от eval'а в Singleton'е путём хака, который используется в таких проектах, как Doctrine, PHPUnit для создания инстанса класса без конструктора. К сожалению, способ через `ReflectionClass->newInstanceWithoutConstructor` доступен только с 5.4, поэтому его использовать не получится для сохранения BC.

Я проверял на PHP 5.2, 5.3.
