### PR TITLE
SmartDaoWorker race condition bug fix

### DIFF
--- a/main/DAOs/Workers/SmartDaoWorker.class.php
+++ b/main/DAOs/Workers/SmartDaoWorker.class.php
@@ -125,13 +125,21 @@
 		{
 			$cache = Cache::me();
 			
-			if (!$map = $cache->mark($this->className)->get($this->indexKey))
+			$mapExists = true;
+			if (!$map = $cache->mark($this->className)->get($this->indexKey)) {
 				$map = array();
+				$mapExists = false;
+			}
 			
 			$map[$objectKey] = true;
-			
-			$cache->mark($this->className)->
-				set($this->indexKey, $map, Cache::EXPIRES_FOREVER);
+
+			if ($mapExists) {
+				$cache->mark($this->className)->
+					replace($this->indexKey, $map, Cache::EXPIRES_FOREVER);
+			} else {
+				$cache->mark($this->className)->
+					set($this->indexKey, $map, Cache::EXPIRES_FOREVER);
+			}
 			
 			return true;
 		}


### PR DESCRIPTION
Проблема возникает тогда, когда один процесс очищает кеш и делает SmartDaoWorker::uncacheLists(), в котором не получает лок на пул ($pool->get($intKey) = false) и просто удаляет из кеша всю карту с листами ($cache->delete($this->indexKey)), а при этом второй процесс параллельно, получив заветный лок на пул ($pool->get($intKey) = true), в конце метода SmartDaoWorker::syncMap() восстанавливает прочитанную ранее и удаленную первым процессом карту с листами с устаревшим значением кеша ($cache->set($this->indexKey, $map).

Это лечится вызовом $cache->replace() вместо $cache->set() в SmartDaoWorker::syncMap() для ранее существовавших карт.
