### PR TITLE
OnPHP meets Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "onphp/onphp",
+    "description": "onPHP is the mature GPL'ed multi-purpose object-oriented PHP framework.",
+    "keywords": ["framework"],
+    "homepage": "https://github.com/onPHP/onphp-framework",
+    "type": "library",
+    "license": "GPL-3.0",
+    "authors": [
+        {
+            "name": "Konstantin Arkhipov"
+        },
+        {
+            "name": "Anton Lebedevich"
+        }
+    ],
+    "require": {
+        "php": ">=5.3.0"
+    },
+    "conflict": {
+        "ext-http": "*"
+    },
+    "autoload": {
+        "classmap": ["core/", "main/", "meta/"]
+    }
+}


### PR DESCRIPTION
В данном PR предлагается добавить поддержку Composer.

Поскольку Composer берёт на себя автозагрузку классов, то стандартный Autoloader не нужен. На данный момент константы из `global.inc.php.tpl` предлагается создавать самому по мере необходимости.

Для проверки можно создать пустой проект с `composer.json` следующего содержания:

``` javascript
{
    "name": "test/test",
    "repositories": [
        {
            "type": "git",
            "url": "https://github.com/DanielPlainview/onphp-framework/"
        }
    ],
    "require": {
        "onphp/onphp": "dev-master"
    }
}
```

и запустить `php composer.phar install`. После можно проверить:

``` php
<?php

require_once __DIR__.'/vendor/autoload.php';

echo Date::create('-42 days')->toString(), PHP_EOL;
```

Чтобы избавиться от блока `repositories` в composer.json нового проекта, требуется зарегистрировать `onphp/onphp` тут: https://packagist.org/packages/submit 
