### PR TITLE
Исправление проверки соединения с бд в MySql

### DIFF
--- a/core/DB/MySQL.class.php
+++ b/core/DB/MySQL.class.php
@@ -96,6 +96,11 @@
 			return $this;
 		}
 		
+		public function isConnected()
+		{
+			return parent::isConnected() && mysql_ping($this->link);
+		}
+		
 		/**
 		 * Same as query, but returns number of
 		 * affected rows in insert/update queries

--- a/core/DB/MySQLim.class.php
+++ b/core/DB/MySQLim.class.php
@@ -81,6 +81,11 @@
 			return $this;
 		}
 		
+		public function isConnected()
+		{
+			return parent::isConnected() && mysqli_ping($this->link);
+		}
+		
 		/**
 		 * Same as query, but returns number of
 		 * affected rows in insert/update queries


### PR DESCRIPTION
Если писать на onPhp демона, то MySql через какое-то время начинает выдавать ошибку "MySQL server has gone away". Для ее предотвращения предлагаю патч.

И, пользуясь случаем, в php 5.5 mysql extension стали deprecated, а с ними и весь класс MySQL. Наверно надо отметить это как-то.
