### PR TITLE
make pgsql error code parsing locale-independent

### DIFF
--- a/core/DB/PgSQL.class.php
+++ b/core/DB/PgSQL.class.php
@@ -100,7 +100,7 @@
 				// manual parsing, since pg_send_query() and
 				// pg_get_result() is too slow in our case
 				list($error, ) = explode("\n", pg_errormessage($this->link));
-				$code = substr($error, 8, 5);
+				sscanf($error, '%*s %[^:]', $code);
 				
 				if ($code == PostgresError::UNIQUE_VIOLATION) {
 					$e = 'DuplicateObjectException';


### PR DESCRIPTION
Original code results in `$code` being filled with wrong characters when database is running in non-english locale. For example, with russian locale `$code` would be "KA:" (from "ОШИБ**КА:** ...", also note that it's not mb_substr, so it actually skips 4 symbols and takes 3 symbols here instead of 8 and 5).

Despite readability, this usage of `sscanf` is proven to be the fastest way to parse it vs. using `explode` or regexps.
