### PR TITLE
Исправление группировки по полю в Criteria через Projection::group

### DIFF
--- a/core/OSQL/QuerySkeleton.class.php
+++ b/core/OSQL/QuerySkeleton.class.php
@@ -178,7 +178,7 @@
 					$field instanceof SelectQuery
 					|| ($field instanceof DialectString	&& $field instanceof Aliased)
 				) {
-					return $field->getAlias();
+					return $field->getAlias() ?: $alias;
 				}
 			}
 			

--- a/test/db/CriteriaDBTest.class.php
+++ b/test/db/CriteriaDBTest.class.php
@@ -4,7 +4,6 @@
 		public function testCriteria()
 		{
 			foreach (DBTestPool::me()->getPool() as $db) {
-				/* @var $db DB */
 				DBPool::me()->setDefault($db);
 				$this->getDBCreator()->fillDB();
 
@@ -13,6 +12,76 @@
 
 				Cache::me()->clean();
 			}
+		}
+
+		public function testDialectsGroupByFunction()
+		{
+			$resultMap = [
+				'PgSQL' => 'SELECT date("test_user"."strange_time") AS "st" FROM "test_user" GROUP BY "st"',
+				'SQLitePDO' => 'SELECT date("test_user"."strange_time") AS "st" FROM "test_user" GROUP BY "st"',
+				'MySQL' => 'SELECT date(`test_user`.`strange_time`) AS `st` FROM `test_user` GROUP BY `st`',
+				'MySQLim' => 'SELECT date(`test_user`.`strange_time`) AS `st` FROM `test_user` GROUP BY `st`',
+			];
+
+			foreach (DBTestPool::me()->getPool() as $db) {
+				$result = $this->getResultByDb($db, $resultMap);
+
+				$criteria =
+					Criteria::create(TestUser::dao())->
+					addProjection(
+						Projection::property(
+							SQLFunction::create(
+								'date', 'strangeTime'
+							),
+
+							'st'
+						)
+					)->
+					addProjection(
+						Projection::group('st')
+					);
+
+				$this->assertEquals(
+					$result,
+					$criteria->toDialectString($db->getDialect())
+				);
+			}
+		}
+
+		public function testDialectsGroupByField()
+		{
+			$resultMap = [
+				'PgSQL' => 'SELECT "test_user"."strange_time" AS "st" FROM "test_user" GROUP BY "st", \'stt\' ORDER BY "st", \'stt\'',
+				'SQLitePDO' => 'SELECT "test_user"."strange_time" AS "st" FROM "test_user" GROUP BY "st", \'stt\' ORDER BY "st", \'stt\'',
+				'MySQL' => 'SELECT `test_user`.`strange_time` AS `st` FROM `test_user` GROUP BY `st`, \'stt\' ORDER BY `st`, \'stt\'',
+				'MySQLim' => 'SELECT `test_user`.`strange_time` AS `st` FROM `test_user` GROUP BY `st`, \'stt\' ORDER BY `st`, \'stt\'',
+			];
+
+			foreach (DBTestPool::me()->getPool() as $db) {
+				$result = $this->getResultByDb($db, $resultMap);
+				$criteria =
+					Criteria::create(TestUser::dao())->
+					addProjection(
+						Projection::property('strangeTime', 'st')
+					)->
+					addProjection(Projection::group('st'))->
+					addProjection(Projection::group('stt'))
+						->addOrder('st')
+						->addOrder('stt');
+
+				$this->assertEquals(
+					$result,
+					$criteria->toDialectString($db->getDialect())
+				);
+			}
+		}
+
+		private function getResultByDb(DB $db, $resultMap)
+		{
+			if (!array_key_exists($class = get_class($db), $resultMap)) {
+				$this->fail("Uknonwn SQL for db ".get_class($db));
+			}
+			return $resultMap[$class];
 		}
 	}
 ?>

--- a/test/misc/DBTestPool.class.php
+++ b/test/misc/DBTestPool.class.php
@@ -38,7 +38,10 @@
 				$connector->setPersistent($persistent)->connect();
 			}
 		}
-		
+
+		/**
+		 * @return DB[]
+		 */
 		public function getPool()
 		{
 			return $this->pool;


### PR DESCRIPTION
Фикс того что было описано в #54. Внезапно решил ещё раз все посмотреть и подебажить и пришел вот к такому испарвлению. Считаю его кривоватым и не уверен что оно на сто процентов корректное но тесты вроде б не ломаются, хотя SQL в них не так что б хорошо покрыт.
Само исправление в QuerySkeleton, остальное это тест из #54.
