### PR TITLE
CaseWhenExpression для PostgreSQL

### DIFF
--- a/core/Logic/CaseWhenExpression.class.php
+++ b/core/Logic/CaseWhenExpression.class.php
@@ -1,0 +1,87 @@
+<?php
+/****************************************************************************
+ *   Copyright (C) 2014 by Alexey S. Denisov                                *
+ *                                                                          *
+ *   This program is free software; you can redistribute it and/or modify   *
+ *   it under the terms of the GNU Lesser General Public License as         *
+ *   published by the Free Software Foundation; either version 3 of the     *
+ *   License, or (at your option) any later version.                        *
+ *                                                                          *
+ ****************************************************************************/
+
+	class CaseWhenExpression implements MappableObject
+	{
+		private $cases = array();
+		private $else = null;
+
+		public static function create($expression = null, $result = null, $else = null)
+		{
+			return new static($expression, $result, $else);
+		}
+
+		public function __construct($expression = null, $result = null, $else = null)
+		{
+			if ($expression !== null && $result !== null) {
+				$this->addCase($expression, $result);
+			}
+			if ($else !== null) {
+				$this->addElse($else);
+			}
+		}
+
+		/**
+		 * @param $expression
+		 * @param $result
+		 * @return CaseWhenExpression
+		 */
+		public function addCase($expression, $result)
+		{
+			$this->cases[] = array($expression, $result);
+			return $this;
+		}
+
+		/**
+		 * @param $result
+		 * @return CaseWhenExpression
+		 */
+		public function addElse($result)
+		{
+			$this->else = $result;
+			return $this;
+		}
+
+		/**
+		 * @param ProtoDAO $dao
+		 * @param JoinCapableQuery $query
+		 * @return MappableObject
+		 */
+		public function toMapped(ProtoDAO $dao, JoinCapableQuery $query)
+		{
+			$expr = new CaseWhenExpression();
+			foreach ($this->cases as $case) {
+				$expr->addCase(
+					$dao->guessAtom($case[0], $query),
+					$dao->guessAtom($case[1], $query)
+				);
+			}
+			if ($this->else) {
+				$expr->addElse($dao->guessAtom($this->else, $query));
+			}
+
+			return $expr;
+		}
+
+		public function toDialectString(Dialect $dialect)
+		{
+			$sqlCases = array();
+			foreach ($this->cases as $case) {
+				$sqlCases[] = 'WHEN '.$dialect->toFieldString($case[0])
+					.' THEN '.$dialect->toValueString($case[1]);
+			}
+			if ($this->else) {
+				$sqlCases[] = 'ELSE '.$dialect->toValueString($this->else);
+			}
+
+			return 'CASE '.implode(' ', $sqlCases).' END';
+		}
+	}

--- a/core/Logic/PrefixUnaryExpression.class.php
+++ b/core/Logic/PrefixUnaryExpression.class.php
@@ -26,7 +26,7 @@
 		 */
 		public static function create($subject, $logic)
 		{
-			return new self($subject, $logic);
+			return new self($logic, $subject);
 		}
 		
 		public function __construct($logic, $subject)

--- a/test/db/CaseWhenExpressionDBTest.class.php
+++ b/test/db/CaseWhenExpressionDBTest.class.php
@@ -1,0 +1,42 @@
+<?php
+	class CaseWhenExpressionDBTest extends TestCaseDAO
+	{
+		/**
+		 * @group caseWhen
+		 */
+		public function testCaseWhenExpression()
+		{
+			$dialect = $this->getDbByType('PgSQL')->getDialect();
+
+			$beautifulNameExpr = CaseWhenExpression::create(
+				Expression::isTrue('capital'),
+				SQLFunction::create('upper', 'name'),
+				SQLFunction::create('lower', 'name')
+			)
+				->addCase(Expression::eq('name', 'St. Peterburg'), 'ST. PETERBURG');
+
+			$orderExpr = CaseWhenExpression::create()
+				->addCase(Expression::isTrue('capital'), SQLFunction::create('upper', 'name'))
+				->addCase(Expression::eq('name', 'St. Peterburg'), 'ST. PETERBURG')
+				->addElse('name');
+
+			$criteria = Criteria::create(TestCity::dao())
+				->addProjection(Projection::property($beautifulNameExpr, 'beautifulName'))
+				->addOrder($orderExpr);
+
+			$expectation = 'SELECT CASE '
+					.'WHEN ("custom_table"."capital" IS TRUE) THEN upper("custom_table"."name") '
+					.'WHEN ("custom_table"."name" = \'St. Peterburg\') THEN \'ST. PETERBURG\' '
+					.'ELSE lower("custom_table"."name") '
+				.'END AS "beautifulName" '
+				.'FROM "custom_table" '
+				.'ORDER BY CASE '
+					.'WHEN ("custom_table"."capital" IS TRUE) THEN upper("custom_table"."name") '
+					.'WHEN ("custom_table"."name" = \'St. Peterburg\') THEN \'ST. PETERBURG\' '
+					.'ELSE "custom_table"."name" '
+				.'END';
+
+			$this->assertEquals($expectation, $criteria->toDialectString($dialect));
+		}
+	}
+?>


### PR DESCRIPTION
На прошлой неделе делал генерацию отчетов и внезапно понадобилось использовать [Conditional Expression](http://www.postgresql.org/docs/8.4/static/functions-conditional.html#AEN15225) выражение из PostgreSQL. Соотвественно написал вот такой вот CaseWhenExpression.

Есть нужно использовать только одно условия и else, то их можно передать в метод create через аргументы - первый аргумент это условие when, второй аргумент - значение/выражение возвращаемое в случае если условие выполняется и третий аргумент это else.
Если необходимо задать дополнительные условия то есть метод addCase с двумя аргемунтами: условие - первый аргумент и то что необходимо вернуть в случае успешного выполнения условия.

В SQL все условия генерируются в порядке их добавления, else всегда ставится последним. При генерации в SQL в случае если в addCase передавались строки, то первая строка по умолчанию считается полем, а вторая считается значением. Соотвественно в случае PostgreSQL они оборачиваются в разные кавычки и по разному эскейпятся.

Возможно в методу toDialectString необходимо добавить Assert на пустое количество условий т.к. в этом случае сгенерируется не валидный SQL. **(Напишите что думаете по этому поводу)**

**Bonus:**
Небольшой фикс в PrefixUnaryExpression::create - перевернул параметры при передаче их в конструктор, т.к. сейчас в create один порядок аргументов, а в конструкторе другой. Моя ошибка был не прав. Это кривой фикс для сохранения BC. С другой стороны PrefixUnaryExpression редко кто использует, думаю, и, пожалуй, можно и изменить порядок аргументов в самом методе create. **(Напишите что думаете и по этому поводу)**
P.S. судя по логу неправильный create по какой-то причине когда-то сделал я
