### PR TITLE
Add group tags to tests. To see available groups:

### DIFF
--- a/tests/Core/AbstractProtoClassFillQueryTest.php
+++ b/tests/Core/AbstractProtoClassFillQueryTest.php
@@ -18,6 +18,11 @@ use OnPHP\Tests\Meta\Business\TestUser;
 use OnPHP\Tests\Meta\Business\TestUserWithContactExtended;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group osql
+ * @group db
+ */
 final class AbstractProtoClassFillQueryTest extends TestCase
 {
 	public function testFullInsertQueryByCity()

--- a/tests/Core/AggregateCacheTest.php
+++ b/tests/Core/AggregateCacheTest.php
@@ -11,6 +11,10 @@ use OnPHP\Core\Cache\SimpleAggregateCache;
 use OnPHP\Core\Cache\SocketMemcached;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group cache
+ */
 final class AggregateCacheTest extends TestCase
 {
 	const QUERIES = 100;

--- a/tests/Core/AssertTest.php
+++ b/tests/Core/AssertTest.php
@@ -6,6 +6,9 @@ use OnPHP\Tests\TestEnvironment\TestCase;
 use OnPHP\Core\Base\Assert;
 use OnPHP\Core\Exception\WrongArgumentException;
 
+/**
+ * @group core
+ */
 final class AssertTest extends TestCase
 {
 	protected $backupGlobals = false;

--- a/tests/Core/BaseCachesTest.php
+++ b/tests/Core/BaseCachesTest.php
@@ -12,6 +12,10 @@ use OnPHP\Core\Cache\SocketMemcached;
 use OnPHP\Core\Cache\WatermarkedPeer;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group cache
+ */
 final class BaseCachesTest extends TestCase
 {
 	public static function cacheProvider()

--- a/tests/Core/CalendarDayTest.php
+++ b/tests/Core/CalendarDayTest.php
@@ -5,6 +5,10 @@ namespace OnPHP\Tests\Core;
 use OnPHP\Main\Base\CalendarDay;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group date
+ */
 final class CalendarDayTest extends TestCase
 {
 	public function testSleeping()

--- a/tests/Core/DateRangeTest.php
+++ b/tests/Core/DateRangeTest.php
@@ -5,7 +5,11 @@ namespace OnPHP\Tests\Core;
 use OnPHP\Core\Base\Date;
 use OnPHP\Main\Base\DateRange;
 use OnPHP\Tests\TestEnvironment\TestCase;
-	
+
+/**
+ * @group core
+ * @group date
+ */
 final class DateRangeTest extends TestCase
 {
 	public function testSplit()

--- a/tests/Core/DateTest.php
+++ b/tests/Core/DateTest.php
@@ -6,6 +6,10 @@ use OnPHP\Core\Base\Date;
 use OnPHP\Core\Base\Timestamp;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group date
+ */
 final class DateTest extends TestCase
 {
 	public function testDayDifference()

--- a/tests/Core/DbConnectionTest.php
+++ b/tests/Core/DbConnectionTest.php
@@ -8,6 +8,11 @@ use OnPHP\Core\Exception\DatabaseException;
 use OnPHP\Main\Monitoring\PinbedPgSQL;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group db
+ * @group monitoring
+ */
 final class DbConnectionTest extends TestCase
 {
 	public function setUp(): void

--- a/tests/Core/DeleteQueryTest.php
+++ b/tests/Core/DeleteQueryTest.php
@@ -9,7 +9,11 @@ use OnPHP\Core\Logic\Expression;
 use OnPHP\Core\OSQL\OSQL;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
-
+/**
+ * @group core
+ * @group db
+ * @group osql
+ */
 final class DeleteQueryTest extends TestCase
 {
 	public function testQuery()

--- a/tests/Core/FiltersTest.php
+++ b/tests/Core/FiltersTest.php
@@ -16,6 +16,10 @@ use OnPHP\Core\Form\Filters\Utf16ConverterFilter;
 use OnPHP\Main\Base\CallChain;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group filter
+ */
 final class FiltersTest extends TestCase
 {
 	public function testTrim()

--- a/tests/Core/FormPrimitivesDateTest.php
+++ b/tests/Core/FormPrimitivesDateTest.php
@@ -7,6 +7,10 @@ use OnPHP\Core\Form\Primitive;
 use OnPHP\Core\Form\Primitives\PrimitiveDate;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group form
+ */
 final class FormPrimitivesDateTest extends TestCase
 {
 	const VALID_DAY		= '22';

--- a/tests/Core/FormTest.php
+++ b/tests/Core/FormTest.php
@@ -13,7 +13,11 @@ use OnPHP\Core\Logic\Expression;
 use OnPHP\Main\Net\HttpUrl;
 use OnPHP\Tests\TestEnvironment\TestCase;
 use OnPHP\Tests\Meta\Business\TestCity;
-	
+
+/**
+ * @group core
+ * @group form
+ */
 final class FormTest extends TestCase
 {
 	public function testRange()

--- a/tests/Core/InnerTransactionTest.php
+++ b/tests/Core/InnerTransactionTest.php
@@ -11,6 +11,11 @@ use OnPHP\Core\Exception\UnimplementedFeatureException;
 use OnPHP\Core\Exception\WrongStateException;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group db
+ * @group postgresql
+ */
 class InnerTransactionTest extends TestCase
 {
 	public function testCommitExt()

--- a/tests/Core/IntervalUnitTest.php
+++ b/tests/Core/IntervalUnitTest.php
@@ -7,6 +7,10 @@ use OnPHP\Core\Base\Timestamp;
 use OnPHP\Main\Base\TimestampRange;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group date
+ */
 final class IntervalUnitTest extends TestCase
 {
 	public function testMicrosecond()

--- a/tests/Core/LockerTest.php
+++ b/tests/Core/LockerTest.php
@@ -5,6 +5,10 @@ namespace OnPHP\Tests\Core;
 use OnPHP\Core\Cache\FileLocker;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group fs
+ */
 final class LockerTest extends TestCase
 {
 	public function testFileLocker()

--- a/tests/Core/LogicTest.php
+++ b/tests/Core/LogicTest.php
@@ -15,6 +15,12 @@ use OnPHP\Core\OSQL\DBField;
 use OnPHP\Core\OSQL\DBValue;
 use OnPHP\Tests\TestEnvironment\TestCaseDB;
 
+/**
+ * @group core
+ * @group db
+ * @group postgresql
+ * @group form
+ */
 final class LogicTest extends TestCaseDB
 {
 	public function testBaseSqlGeneration()

--- a/tests/Core/PrimitiveAliasTest.php
+++ b/tests/Core/PrimitiveAliasTest.php
@@ -25,6 +25,10 @@ final class PrimitiveCustomError extends PrimitiveString
 	}
 }
 
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveAliasTest extends TestCase
 {
 	public function testImport()

--- a/tests/Core/PrimitiveClassTest.php
+++ b/tests/Core/PrimitiveClassTest.php
@@ -9,6 +9,10 @@ use OnPHP\Core\Exception\WrongArgumentException;
 use OnPHP\Core\Form\Primitive;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveClassTest extends TestCase
 {
 	public function test()

--- a/tests/Core/PrimitiveDateRangeTest.php
+++ b/tests/Core/PrimitiveDateRangeTest.php
@@ -6,6 +6,11 @@ use OnPHP\Core\Base\Date;
 use OnPHP\Core\Form\Primitives\PrimitiveDateRange;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group form
+ * @group date
+ */
 final class PrimitiveDateRangeTest extends TestCase
 {
 	public function testImport()

--- a/tests/Core/PrimitiveEnumTest.php
+++ b/tests/Core/PrimitiveEnumTest.php
@@ -16,6 +16,10 @@ use OnPHP\Core\Form\Primitive;
 use OnPHP\Main\Base\MimeType;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveEnumTest extends TestCase
 {
 	public function testIntegerValues()

--- a/tests/Core/PrimitiveEnumerationTest.php
+++ b/tests/Core/PrimitiveEnumerationTest.php
@@ -7,6 +7,10 @@ use OnPHP\Core\Form\Primitive;
 use OnPHP\Core\OSQL\DataType;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveEnumerationTest extends TestCase
 {
 	public function testIntegerValues()

--- a/tests/Core/PrimitiveHstoreTest.php
+++ b/tests/Core/PrimitiveHstoreTest.php
@@ -9,6 +9,10 @@ use OnPHP\Core\Form\Primitives\PrimitiveHstore;
 use OnPHP\Tests\TestEnvironment\TestCase;
 use OnPHP\Main\Base\Hstore;
 
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveHstoreTest extends TestCase
 {
 	protected static $scope =

--- a/tests/Core/PrimitiveHttpUrlTest.php
+++ b/tests/Core/PrimitiveHttpUrlTest.php
@@ -15,6 +15,10 @@ use OnPHP\Core\Form\Form;
 use OnPHP\Core\Form\Primitive;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveHttpUrlTest extends TestCase
 {
 	private $urlWithPrivilegedPort = "https://path.to.some.com:444/hey.html";

--- a/tests/Core/PrimitiveIdentifierTest.php
+++ b/tests/Core/PrimitiveIdentifierTest.php
@@ -11,6 +11,12 @@ use OnPHP\Tests\Meta\Business\TestCity;
 use OnPHP\Tests\TestEnvironment\DBTestPool;
 use OnPHP\Tests\TestEnvironment\TestCaseDAO;
 
+/**
+ * @group core
+ * @group form
+ * @group db
+ * @group dao
+ */
 final class PrimitiveIdentifierTest extends TestCaseDAO
 {
 	public function testEmpty()
@@ -31,9 +37,6 @@ final class PrimitiveIdentifierTest extends TestCaseDAO
 		}
 	}
 
-	/**
-	 * @group pi
-	 */
 	public function testCustomImportExport()
 	{
 		$dbs = DBTestPool::me()->getPool();

--- a/tests/Core/PrimitiveInetTest.php
+++ b/tests/Core/PrimitiveInetTest.php
@@ -5,6 +5,10 @@ namespace OnPHP\Tests\Core;
 use OnPHP\Core\Form\Primitive;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveInetTest extends TestCase
 {
 	public function testInet()

--- a/tests/Core/PrimitiveIpTest.php
+++ b/tests/Core/PrimitiveIpTest.php
@@ -6,6 +6,10 @@ use OnPHP\Core\Form\Primitive;
 use OnPHP\Main\Net\Ip\IpAddress;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveIpTest extends TestCase
 {
 	public function testBase()

--- a/tests/Core/PrimitiveNumberTest.php
+++ b/tests/Core/PrimitiveNumberTest.php
@@ -5,6 +5,10 @@ namespace OnPHP\Tests\Core;
 use OnPHP\Core\Form\Primitive;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveNumberTest extends TestCase
 {
 	public function testInteger()

--- a/tests/Core/PrimitiveStringTest.php
+++ b/tests/Core/PrimitiveStringTest.php
@@ -6,6 +6,10 @@ use OnPHP\Core\Form\Primitive;
 use OnPHP\Core\Form\Primitives\PrimitiveString;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveStringTest extends TestCase
 {
 	public function testImport()

--- a/tests/Core/PrimitiveTimeTest.php
+++ b/tests/Core/PrimitiveTimeTest.php
@@ -6,6 +6,10 @@ use OnPHP\Core\Base\Time;
 use OnPHP\Core\Form\Primitive;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveTimeTest extends TestCase
 {
 	public function testImport()

--- a/tests/Core/PrimitiveTimestampTZTest.php
+++ b/tests/Core/PrimitiveTimestampTZTest.php
@@ -8,6 +8,10 @@ use OnPHP\Core\Form\Primitives\PrimitiveTimestamp;
 use OnPHP\Core\Form\Primitives\PrimitiveTimestampTZ;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveTimestampTZTest extends TestCase
 {
 

--- a/tests/Core/PrimitiveTimestampTest.php
+++ b/tests/Core/PrimitiveTimestampTest.php
@@ -7,6 +7,10 @@ use OnPHP\Core\Form\Primitives\PrimitiveDate;
 use OnPHP\Core\Form\Primitives\PrimitiveTimestamp;
 use OnPHP\Tests\TestEnvironment\TestCase;
 	
+/**
+ * @group core
+ * @group form
+ */
 final class PrimitiveTimestampTest extends TestCase
 {
 	public function testMarried()

--- a/tests/Core/SequentialCacheTest.php
+++ b/tests/Core/SequentialCacheTest.php
@@ -18,6 +18,11 @@ use OnPHP\Core\Cache\SequentialCache;
 use OnPHP\Core\Cache\SocketMemcached;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group cache
+ * @group memcached
+ */
 final class SequentialCacheTest extends TestCase
 {
 	public function testMultiCacheAliveLast()

--- a/tests/Core/SingletonTest.php
+++ b/tests/Core/SingletonTest.php
@@ -21,6 +21,9 @@ final class SingletonMultiArgumentTestInstance extends Singleton
 	protected function __construct($arg1, $arg2, $arg3 = null) { /*_*/ }
 }
 
+/**
+ * @group core
+ */
 final class SingletonTest extends TestCase
 {
 	const CLASS_NAME		= SingletonTestInstance::class;

--- a/tests/Core/TimestampTZTest.php
+++ b/tests/Core/TimestampTZTest.php
@@ -5,11 +5,12 @@ use OnPHP\Core\Base\TimestampTZ;
 use OnPHP\Core\DB\ImaginaryDialect;
 use OnPHP\Tests\TestEnvironment\TestCase;
 	
+/**
+ * @group core
+ * @group date
+ */
 final class TimestampTZTest extends TestCase
 {
-	/**
-	 * @group ff
-	 */
 	public function testDifferentZones()
 	{
 		$someDate = TimestampTZ::create('2011-01-01 12:10:10 Europe/Moscow');
@@ -40,9 +41,6 @@ final class TimestampTZTest extends TestCase
 		);
 	}
 
-	/**
-	 * @group ff
-	 */
 	public function testDialect()
 	{
 		//setup
@@ -57,9 +55,6 @@ final class TimestampTZTest extends TestCase
 		);
 	}
 
-	/**
-	 * @group ff
-	 */
 	public function testSleeping() {
 		$time = TimestampTZ::create('2011-03-08 12:12:12 PST');
 		$sleepedTime = unserialize(serialize($time));

--- a/tests/Core/TimestampTest.php
+++ b/tests/Core/TimestampTest.php
@@ -7,6 +7,10 @@ use OnPHP\Core\Base\Timestamp;
 use OnPHP\Core\Exception\WrongArgumentException;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group date
+ */
 final class TimestampTest extends TestCase
 {	
 	public function testNonEpoch()

--- a/tests/Core/TruncateQueryTest.php
+++ b/tests/Core/TruncateQueryTest.php
@@ -9,6 +9,14 @@ use OnPHP\Core\Exception\WrongArgumentException;
 use OnPHP\Core\OSQL\OSQL;
 use OnPHP\Tests\TestEnvironment\TestCaseDB;
 
+/**
+ * @group core
+ * @group db
+ * @group osql
+ * @group mysql
+ * @group postgresql
+ * @group sqlite
+ */
 final class TruncateQueryTest extends TestCaseDB
 {
 	public function testQuery()

--- a/tests/Core/UnionTest.php
+++ b/tests/Core/UnionTest.php
@@ -7,6 +7,12 @@ use OnPHP\Core\OSQL\CombineQuery;
 use OnPHP\Core\OSQL\OSQL;
 use OnPHP\Tests\TestEnvironment\TestCaseDB;
 
+/**
+ * @group core
+ * @group db
+ * @group osql
+ * @group postgresql
+ */
 final class UnionTest extends TestCaseDB
 {
 	private $singleUnion 		= null;

--- a/tests/DB/CacheAndLazyDBTest.php
+++ b/tests/DB/CacheAndLazyDBTest.php
@@ -14,6 +14,12 @@ use OnPHP\Tests\Meta\Business\TestSubItem;
 use OnPHP\Tests\TestEnvironment\DBTestPool;
 use OnPHP\Tests\TestEnvironment\TestCaseDAO;
 
+/**
+ * @group core
+ * @group db
+ * @group dao
+ * @group criteria
+ */
 class CacheAndLazyDBTest extends TestCaseDAO
 {
 	public function testWorkingWithCache()

--- a/tests/DB/CountAndUnifiedDBTest.php
+++ b/tests/DB/CountAndUnifiedDBTest.php
@@ -16,6 +16,12 @@ use OnPHP\Tests\Meta\Business\TestUser;
 use OnPHP\Tests\TestEnvironment\DBTestPool;
 use OnPHP\Tests\TestEnvironment\TestCaseDAO;
 
+/**
+ * @group core
+ * @group db
+ * @group dao
+ * @group criteria
+ */
 class CountAndUnifiedDBTest extends TestCaseDAO
 {
 	public function testUnified()

--- a/tests/DB/CriteriaDBTest.php
+++ b/tests/DB/CriteriaDBTest.php
@@ -10,6 +10,11 @@ use OnPHP\Tests\Meta\Business\TestCity;
 use OnPHP\Tests\TestEnvironment\DBTestPool;
 use OnPHP\Tests\TestEnvironment\TestCaseDAO;
 
+/**
+ * @group core
+ * @group db
+ * @group criteria
+ */
 class CriteriaDBTest extends TestCaseDAO
 {
 	public function testCriteria()

--- a/tests/DB/DataDBTest.php
+++ b/tests/DB/DataDBTest.php
@@ -21,6 +21,11 @@ use OnPHP\Tests\Meta\Business\TestUser;
 use OnPHP\Tests\TestEnvironment\DBTestPool;
 use OnPHP\Tests\TestEnvironment\TestCaseDAO;
 
+/**
+ * @group core
+ * @group db
+ * @group dao
+ */
 class DataDBTest extends TestCaseDAO
 {
 	public function testData()

--- a/tests/DB/HstoreDBTest.php
+++ b/tests/DB/HstoreDBTest.php
@@ -14,6 +14,11 @@ use OnPHP\Tests\Meta\Business\TestUser;
 use OnPHP\Tests\TestEnvironment\DBTestPool;
 use OnPHP\Tests\TestEnvironment\TestCaseDAO;
 
+/**
+ * @group core
+ * @group db
+ * @group dao
+ */
 class HstoreDBTest extends TestCaseDAO
 {
 	/**

--- a/tests/DB/IdDBTest.php
+++ b/tests/DB/IdDBTest.php
@@ -11,6 +11,11 @@ use OnPHP\Tests\Meta\Business\TestUser;
 use OnPHP\Tests\TestEnvironment\DBTestPool;
 use OnPHP\Tests\TestEnvironment\TestCaseDAO;
 
+/**
+ * @group core
+ * @group db
+ * @group dao
+ */
 class IdDBTest extends TestCaseDAO
 {
 	public function testGetByEmptyId()

--- a/tests/DB/InnerTransactionDBTest.php
+++ b/tests/DB/InnerTransactionDBTest.php
@@ -11,6 +11,11 @@ use OnPHP\Tests\Meta\Business\TestCity;
 use OnPHP\Tests\TestEnvironment\DBTestPool;
 use OnPHP\Tests\TestEnvironment\TestCaseDAO;
 
+/**
+ * @group core
+ * @group db
+ * @group dao
+ */
 class InnerTransactionDBTest extends TestCaseDAO
 {
 	public function setUp() : void

--- a/tests/DB/IpDBTest.php
+++ b/tests/DB/IpDBTest.php
@@ -20,7 +20,13 @@ use OnPHP\Tests\TestEnvironment\DBTestPool;
 use OnPHP\Tests\TestEnvironment\TestCaseDAO;
 
 /**
- * @group ipdb
+ * @group core
+ * @group main
+ * @group db
+ * @group osql
+ * @group criteria
+ * @group postgresql
+ * @group ip
  */
 class IpDBTest extends TestCaseDAO
 {

--- a/tests/DB/PgSQLFullTextSearchDBTest.php
+++ b/tests/DB/PgSQLFullTextSearchDBTest.php
@@ -8,7 +8,9 @@ use OnPHP\Tests\TestEnvironment\DBTestPool;
 use OnPHP\Tests\TestEnvironment\TestCaseDB;
 
 /**
- * @group pgsf
+ * @group core
+ * @group db
+ * @group postgresql
  */
 class PgSQLFullTextSearchDBTest extends TestCaseDB
 {

--- a/tests/DB/RecursionDBTest.php
+++ b/tests/DB/RecursionDBTest.php
@@ -14,7 +14,9 @@ use OnPHP\Tests\TestEnvironment\DBTestPool;
 use OnPHP\Tests\TestEnvironment\TestCaseDAO;
 
 /**
- * @group rdb
+ * @group core
+ * @group db
+ * @group dao
  */
 class RecursionDBTest extends TestCaseDAO
 {

--- a/tests/Main/Base62UtilsTest.php
+++ b/tests/Main/Base62UtilsTest.php
@@ -14,6 +14,9 @@ use OnPHP\Core\Exception\WrongArgumentException;
 use OnPHP\Main\Crypto\Base62Utils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ */
 final class Base62UtilsTest extends TestCase
 {
 	public function testSetCharsLengthFailed()

--- a/tests/Main/ClassUtilsTest.php
+++ b/tests/Main/ClassUtilsTest.php
@@ -15,6 +15,9 @@ use OnPHP\Tests\TestEnvironment\ClassUtilsTestClassChild;
 use OnPHP\Tests\TestEnvironment\ClassUtilsTestInterface;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ */
 final class ClassUtilsTest extends TestCase
 {
 	

--- a/tests/Main/ComparatorTest.php
+++ b/tests/Main/ComparatorTest.php
@@ -9,6 +9,9 @@ use OnPHP\Main\Base\ImmutableObjectComparator;
 use OnPHP\Main\Base\SerializedObjectComparator;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ */
 final class ComparatorTest extends TestCase
 {
 	/**

--- a/tests/Main/CriteriaTest.php
+++ b/tests/Main/CriteriaTest.php
@@ -21,6 +21,11 @@ use OnPHP\Tests\Meta\Business\TestUserWithContactExtended;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
 
+/**
+ * @group core
+ * @group db
+ * @group criteria
+ */
 final class CriteriaTest extends TestCase
 {
 	public function testClassProjection()

--- a/tests/Main/CrypterTest.php
+++ b/tests/Main/CrypterTest.php
@@ -5,6 +5,10 @@ namespace OnPHP\Tests\Main;
 use OnPHP\Main\Crypto\Crypter;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group crypto
+ */
 final class CrypterTest extends TestCase
 {
 	/**

--- a/tests/Main/CryptoTest.php
+++ b/tests/Main/CryptoTest.php
@@ -23,6 +23,10 @@ use OnPHP\Main\Math\RandomSource;
 use OnPHP\Main\Util\TextUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group crypto
+ */
 final class CryptoTest extends TestCase
 {
 	public function runDiffieHellmanExchange(

--- a/tests/Main/CsvTest.php
+++ b/tests/Main/CsvTest.php
@@ -14,6 +14,10 @@ namespace OnPHP\Tests\Main;
 use OnPHP\Main\Markup\Csv;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group csv
+ */
 final class CsvTest extends TestCase
 {
 	public function testRender()

--- a/tests/Main/DateUtilsTest.php
+++ b/tests/Main/DateUtilsTest.php
@@ -6,6 +6,10 @@ use OnPHP\Core\Base\Timestamp;
 use OnPHP\Main\Util\DateUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group date
+ */
 final class DateUtilsTest extends TestCase
 {
 	/**

--- a/tests/Main/EntityProtoConvertersTest.php
+++ b/tests/Main/EntityProtoConvertersTest.php
@@ -18,6 +18,10 @@ use OnPHP\Tests\TestEnvironment\DirectoryItem;
 use OnPHP\Tests\TestEnvironment\EntityProtoDirectoryItem;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group proto
+ */
 final class EntityProtoConvertersTest extends TestCase
 {
 	public function testDirectoryBinder()

--- a/tests/Main/EnumerationTest.php
+++ b/tests/Main/EnumerationTest.php
@@ -7,6 +7,9 @@ use OnPHP\Core\Exception\MissingElementException;
 use OnPHP\Main\Util\ClassUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 	
+/**
+ * @group main
+ */
 final class EnumerationTest extends TestCase
 {
 	/**

--- a/tests/Main/FeedReaderTest.php
+++ b/tests/Main/FeedReaderTest.php
@@ -7,6 +7,9 @@ use OnPHP\Main\Markup\Feed\FeedReader;
 use OnPHP\Main\Markup\Feed\YandexRssFeedItem;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ */
 final class FeedReaderTest extends TestCase
 {
 	public function testFeedReaderRss()

--- a/tests/Main/FloatRangeTest.php
+++ b/tests/Main/FloatRangeTest.php
@@ -6,6 +6,9 @@ use OnPHP\Core\Exception\WrongArgumentException;
 use OnPHP\Main\Base\FloatRange;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ */
 final class FloatRangeTest extends TestCase
 {
 	/**

--- a/tests/Main/GenericUriTest.php
+++ b/tests/Main/GenericUriTest.php
@@ -14,6 +14,10 @@ use OnPHP\Main\Net\Urn;
 use OnPHP\Main\Util\ClassUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group http
+ */
 final class GenericUriTest extends TestCase
 {
 	private $urls = array(

--- a/tests/Main/GoogleChartTest.php
+++ b/tests/Main/GoogleChartTest.php
@@ -20,7 +20,10 @@ use OnPHP\Main\Charts\Google\GoogleNormalizedLineChart;
 use OnPHP\Main\Charts\Google\GooglePieChart;
 use OnPHP\Main\Util\TuringTest\Color;
 use OnPHP\Tests\TestEnvironment\TestCase;
-	
+
+/**
+ * @group utils
+ */
 final class GoogleChartTest extends TestCase
 {
 	public function testPieChart()

--- a/tests/Main/HeaderParserTest.php
+++ b/tests/Main/HeaderParserTest.php
@@ -14,6 +14,10 @@ namespace OnPHP\Tests\Main;
 use OnPHP\Main\Net\Http\HeaderParser;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group http
+ */
 class HeaderParserTest extends TestCase
 {
 	public function testSimple()

--- a/tests/Main/HstoreTest.php
+++ b/tests/Main/HstoreTest.php
@@ -14,6 +14,9 @@ namespace OnPHP\Tests\Main;
 use OnPHP\Main\Base\Hstore;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ */
 final class HstoreTest extends TestCase
 {
 	public function testRun()

--- a/tests/Main/HttpUrlTest.php
+++ b/tests/Main/HttpUrlTest.php
@@ -14,6 +14,10 @@ namespace OnPHP\Tests\Main;
 use OnPHP\Main\Net\HttpUrl;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group http
+ */
 final class HttpUrlTest extends TestCase
 {
 	private $urlWithPrivilegedPort = "https://path.to.some.com:444/hey.html";

--- a/tests/Main/HttpUtilsTest.php
+++ b/tests/Main/HttpUtilsTest.php
@@ -19,6 +19,12 @@ use OnPHP\Main\Net\Http\HttpStatus;
 use OnPHP\Main\Net\HttpUrl;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group utils
+ * @group http
+ * @group curl
+ */
 final class HttpUtilsTest extends TestCase
 {
 	public function testCurlGet()

--- a/tests/Main/Ip/IpAddressTest.php
+++ b/tests/Main/Ip/IpAddressTest.php
@@ -5,6 +5,10 @@ namespace OnPHP\Tests\Main\Ip;
 use OnPHP\Main\Net\Ip\IpAddress;
 use OnPHP\Tests\TestEnvironment\TestCase;
 	
+/**
+ * @group main
+ * @group ip
+ */
 final class IpAddressTest extends TestCase
 {
 	private $ips = 

--- a/tests/Main/Ip/IpBaseRangeTest.php
+++ b/tests/Main/Ip/IpBaseRangeTest.php
@@ -10,7 +10,8 @@ use OnPHP\Main\Net\Ip\IpRange;
 use OnPHP\Tests\TestEnvironment\TestCaseDB;
 
 /**
- * @group ibr
+ * @group main
+ * @group ip
  */
 final class IpBaseRangeTest extends TestCaseDB
 {

--- a/tests/Main/Ip/IpNetworkTest.php
+++ b/tests/Main/Ip/IpNetworkTest.php
@@ -6,6 +6,10 @@ use OnPHP\Main\Net\Ip\IpAddress;
 use OnPHP\Main\Net\Ip\IpNetwork;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group ip
+ */
 final class IpNetworkTest extends TestCase
 {
 	public function testContains()

--- a/tests/Main/Ip/IpUtilsTest.php
+++ b/tests/Main/Ip/IpUtilsTest.php
@@ -5,7 +5,10 @@ namespace OnPHP\Tests\Main\Ip;
 use OnPHP\Main\Net\Ip\IpUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
-/* $Id$ */	
+/**
+ * @group main
+ * @group ip
+ */
 final class IpUtilsTest extends TestCase
 {
 	/**

--- a/tests/Main/JsonPViewTest.php
+++ b/tests/Main/JsonPViewTest.php
@@ -18,6 +18,10 @@ use OnPHP\Main\Flow\Model;
 use OnPHP\Main\UI\View\JsonPView;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group view
+ */
 final class JsonPViewTest extends TestCase
 {
 	protected $array = array('<foo>',"'bar'",'"baz"','&blong&');

--- a/tests/Main/JsonViewTest.php
+++ b/tests/Main/JsonViewTest.php
@@ -15,6 +15,10 @@ use OnPHP\Main\Flow\Model;
 use OnPHP\Main\UI\View\JsonView;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group view
+ */
 final class JsonViewTest extends TestCase
 {
 	protected $array = array('<foo>',"'bar'",'"baz"','&blong&');

--- a/tests/Main/JsonXssViewTest.php
+++ b/tests/Main/JsonXssViewTest.php
@@ -15,6 +15,10 @@ use OnPHP\Main\Flow\Model;
 use OnPHP\Main\UI\View\JsonXssView;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group view
+ */
 final class JsonXssViewTest extends TestCase
 {
 	protected $array = array('<foo>',"'bar'",'"baz"','&blong&');

--- a/tests/Main/MathTest.php
+++ b/tests/Main/MathTest.php
@@ -19,6 +19,10 @@ use OnPHP\Main\Math\MtRandomSource;
 use OnPHP\Main\Math\RandomSource;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group math
+ */
 final class MathTest extends TestCase
 {
 	public function runMathTest(BigNumberFactory $factory)

--- a/tests/Main/MathUtilsTest.php
+++ b/tests/Main/MathUtilsTest.php
@@ -15,6 +15,10 @@ use OnPHP\Core\Exception\WrongArgumentException;
 use OnPHP\Main\Math\MathUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group math
+ */
 final class MathUtilsTest extends TestCase
 {
 	public function testCompareFloat()

--- a/tests/Main/MessagesTest.php
+++ b/tests/Main/MessagesTest.php
@@ -8,6 +8,10 @@ use OnPHP\Main\Message\TextFileSender;
 use OnPHP\Main\Message\TextMessage;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group text
+ */
 final class MessagesTest extends TestCase
 {
 	public function testFileQueue()

--- a/tests/Main/MimeMailTest.php
+++ b/tests/Main/MimeMailTest.php
@@ -7,6 +7,11 @@ use OnPHP\Main\Net\Mail\MimeMail;
 use OnPHP\Main\Net\Mail\MimePart;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group http
+ * @group mail
+ */
 final class MimeMailTest extends TestCase
 {
 	public function testMimeMail()

--- a/tests/Main/Net/CookieTest.php
+++ b/tests/Main/Net/CookieTest.php
@@ -7,6 +7,11 @@ use OnPHP\Main\Net\Http\Cookie;
 use OnPHP\Main\Net\Http\CookieCollection;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group http
+ * @group cookie
+ */
 final class CookieTest extends TestCase
 {
 	public function testCookie()

--- a/tests/Main/Net/CurlHttpClientTest.php
+++ b/tests/Main/Net/CurlHttpClientTest.php
@@ -11,6 +11,11 @@ use OnPHP\Main\Net\Http\HttpMethod;
 use OnPHP\Main\Util\UrlParamsUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group http
+ * @group curl
+ */
 final class CurlHttpClientTest extends TestCase
 {
 	private static $failTestMsg = null;

--- a/tests/Main/Net/Http/HttpHeaderCollectionTest.php
+++ b/tests/Main/Net/Http/HttpHeaderCollectionTest.php
@@ -15,6 +15,10 @@ use OnPHP\Core\Exception\MissingElementException;
 use OnPHP\Main\Net\Http\HttpHeaderCollection;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group http
+ */
 class HttpHeaderCollectionTest extends TestCase
 {
 	/**

--- a/tests/Main/Net/MailTest.php
+++ b/tests/Main/Net/MailTest.php
@@ -17,6 +17,11 @@ use OnPHP\Main\Net\Mail\MailAddress;
 use OnPHP\Main\Net\Mail\MailNotSentException;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group http
+ * @group mail
+ */
 final class MailTest extends TestCase
 {
 	public function testMailAddressWithoutPerson()

--- a/tests/Main/OpenIdTest.php
+++ b/tests/Main/OpenIdTest.php
@@ -21,6 +21,10 @@ use OnPHP\Main\OpenId\OpenIdCredentials;
 use OnPHP\Main\OpenId\OpenIdException;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group http
+ */
 final class OpenIdTest extends TestCase
 {
 	public function testCredentials()

--- a/tests/Main/OqlSelectClauseTest.php
+++ b/tests/Main/OqlSelectClauseTest.php
@@ -15,6 +15,12 @@ use OnPHP\Main\OQL\Statement\OqlQuery;
 use OnPHP\Tests\Meta\Business\TestUser;
 use OnPHP\Tests\TestEnvironment\TestCaseDB;
 
+/**
+ * @group core
+ * @group db
+ * @group oql
+ * @group criteria
+ */
 final class OqlSelectClauseTest extends TestCaseDB
 {	
 	public function testEmpty()

--- a/tests/Main/OqlSelectTest.php
+++ b/tests/Main/OqlSelectTest.php
@@ -16,6 +16,12 @@ use OnPHP\Tests\Meta\Business\TestCity;
 use OnPHP\Tests\Meta\Business\TestUser;
 use OnPHP\Tests\TestEnvironment\TestCaseDB;
 
+/**
+ * @group core
+ * @group db
+ * @group oql
+ * @group criteria
+ */
 final class OqlSelectTest extends TestCaseDB
 {
 	public function testProperty()

--- a/tests/Main/OqlTokenizerTest.php
+++ b/tests/Main/OqlTokenizerTest.php
@@ -6,6 +6,11 @@ use OnPHP\Main\OQL\Parser\OqlToken;
 use OnPHP\Main\OQL\Parser\OqlTokenizer;
 use OnPHP\Tests\TestEnvironment\TestCase;
 	
+/**
+ * @group core
+ * @group db
+ * @group oql
+ */
 final class OqlTokenizerTest extends TestCase
 {
 	public function testEmpty()

--- a/tests/Main/OsqlDeleteTest.php
+++ b/tests/Main/OsqlDeleteTest.php
@@ -8,6 +8,12 @@ use OnPHP\Core\Logic\Expression;
 use OnPHP\Core\OSQL\OSQL;
 use OnPHP\Tests\TestEnvironment\TestCaseDB;
 
+/**
+ * @group core
+ * @group db
+ * @group osql
+ * @group postgresql
+ */
 final class OsqlDeleteTest extends TestCaseDB
 {
 	public function testQuery()

--- a/tests/Main/OsqlInsertTest.php
+++ b/tests/Main/OsqlInsertTest.php
@@ -8,6 +8,12 @@ use OnPHP\Core\OSQL\DBValue;
 use OnPHP\Core\OSQL\OSQL;
 use OnPHP\Tests\TestEnvironment\TestCaseDB;
 
+/**
+ * @group core
+ * @group db
+ * @group osql
+ * @group postgresql
+ */
 final class OsqlInsertTest extends TestCaseDB
 {
 	public function testInsertFromSelect()

--- a/tests/Main/OsqlReturningTest.php
+++ b/tests/Main/OsqlReturningTest.php
@@ -13,6 +13,12 @@ use OnPHP\Core\OSQL\OSQL;
 use OnPHP\Core\OSQL\SQLFunction;
 use OnPHP\Tests\TestEnvironment\TestCaseDB;
 
+/**
+ * @group core
+ * @group db
+ * @group osql
+ * @group postgresql
+ */
 final class OsqlReturningTest extends TestCaseDB
 {
 	public function testUpdate()

--- a/tests/Main/OsqlSelectTest.php
+++ b/tests/Main/OsqlSelectTest.php
@@ -11,6 +11,12 @@ use OnPHP\Core\OSQL\OSQL;
 use OnPHP\Core\OSQL\SQLFunction;
 use OnPHP\Tests\TestEnvironment\TestCaseDB;
 	
+/**
+ * @group core
+ * @group db
+ * @group osql
+ * @group postgresql
+ */
 final class OsqlSelectTest extends TestCaseDB
 {
 	public function testSelectGet()

--- a/tests/Main/RangeTest.php
+++ b/tests/Main/RangeTest.php
@@ -6,6 +6,9 @@ use OnPHP\Core\Exception\WrongArgumentException;
 use OnPHP\Main\Base\Range;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ */
 final class RangeTest extends TestCase
 {
 	/**

--- a/tests/Main/RedisNoSQLTest.php
+++ b/tests/Main/RedisNoSQLTest.php
@@ -14,6 +14,11 @@ namespace OnPHP\Tests\Main;
 use OnPHP\Core\DB\NoSQL\RedisNoSQL;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group core
+ * @group cache
+ * @group redis
+ */
 final class RedisNoSQLTest extends TestCase
 {
 	public function setUp() :void

--- a/tests/Main/TextUtilsTest.php
+++ b/tests/Main/TextUtilsTest.php
@@ -5,6 +5,9 @@ namespace OnPHP\Tests\Main;
 use OnPHP\Main\Util\TextUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 	
+/**
+ * @group utils
+ */
 final class TextUtilsTest extends TestCase
 {
 	public function testFriendlyFileSize()

--- a/tests/Main/Utils/AMQP/AMQPPeclTest.php
+++ b/tests/Main/Utils/AMQP/AMQPPeclTest.php
@@ -102,6 +102,10 @@ class AMQPTestCaseAutoAckQueueConsumer extends AMQPPeclQueueConsumer
 	}
 }
 
+/**
+ * @group utils
+ * @group amqp
+ */
 class AMQPPeclTest extends TestCase
 {
 	const COUNT_OF_PUBLISH = 5;

--- a/tests/Main/Utils/ArrayUtilsTest.php
+++ b/tests/Main/Utils/ArrayUtilsTest.php
@@ -9,6 +9,9 @@ use OnPHP\Main\Util\ArrayUtils;
 use OnPHP\Tests\Meta\Business\TestCity;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ */
 final class ArrayUtilsTest extends TestCase
 {
 	/**

--- a/tests/Main/Utils/FileUtilsTest.php
+++ b/tests/Main/Utils/FileUtilsTest.php
@@ -5,6 +5,10 @@ namespace OnPHP\Tests\Main\Utils;
 use OnPHP\Main\Util\FileUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group fs
+ */
 final class FileUtilsTest extends TestCase
 {
 	public function testUniqueNames()

--- a/tests/Main/Utils/PinbaTest.php
+++ b/tests/Main/Utils/PinbaTest.php
@@ -5,6 +5,11 @@ namespace OnPHP\Tests\Main\Utils;
 use OnPHP\Main\Monitoring\PinbaClient;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group monitoring
+ * @group pinba
+ */
 final class PinbaTest extends TestCase
 {
 	protected static $skipMessage	= 'unknown error';

--- a/tests/Main/Utils/Routers/RouterBaseRuleTest.php
+++ b/tests/Main/Utils/Routers/RouterBaseRuleTest.php
@@ -28,6 +28,10 @@ class RouterBaseRuleStub extends RouterBaseRule
 	public function assembly(array $data = array(), $reset = false, $encode = false) {/**/}
 }
 
+/**
+ * @group utils
+ * @group router
+ */
 class RouterBaseRuleTest extends TestCase
 {
 	/**

--- a/tests/Main/Utils/Routers/RouterChainRuleTest.php
+++ b/tests/Main/Utils/Routers/RouterChainRuleTest.php
@@ -13,6 +13,10 @@ use OnPHP\Main\Util\Router\RouterTransparentRule;
 use OnPHP\Tests\TestEnvironment\ServerVarUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group router
+ */
 class RouterChainRuleTest extends TestCase
 {
 	public function setUp(): void

--- a/tests/Main/Utils/Routers/RouterHostnameRuleTest.php
+++ b/tests/Main/Utils/Routers/RouterHostnameRuleTest.php
@@ -8,6 +8,10 @@ use OnPHP\Main\Util\Router\RouterHostnameRule;
 use OnPHP\Tests\TestEnvironment\ServerVarUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group router
+ */
 class RouterHostnameRuleTest extends TestCase
 {
 	public function setUp(): void

--- a/tests/Main/Utils/Routers/RouterRegexpRuleTest.php
+++ b/tests/Main/Utils/Routers/RouterRegexpRuleTest.php
@@ -8,6 +8,10 @@ use OnPHP\Main\Util\Router\RouterRegexpRule;
 use OnPHP\Tests\TestEnvironment\ServerVarUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group router
+ */
 class RouterRegexpRuleTest extends TestCase
 {
 	public function setUp(): void

--- a/tests/Main/Utils/Routers/RouterRewriteTest.php
+++ b/tests/Main/Utils/Routers/RouterRewriteTest.php
@@ -15,6 +15,10 @@ use OnPHP\Main\Util\Router\RouterTransparentRule;
 use OnPHP\Tests\TestEnvironment\ServerVarUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group router
+ */
 class RouterRewriteTest extends TestCase
 {
 	/**

--- a/tests/Main/Utils/Routers/RouterStaticRuleTest.php
+++ b/tests/Main/Utils/Routers/RouterStaticRuleTest.php
@@ -7,6 +7,10 @@ use OnPHP\Main\Util\Router\RouterStaticRule;
 use OnPHP\Tests\TestEnvironment\ServerVarUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group router
+ */
 class RouterStaticRuleTest extends TestCase
 {
 	public function setUp(): void

--- a/tests/Main/Utils/Routers/RouterTransparentRuleTest.php
+++ b/tests/Main/Utils/Routers/RouterTransparentRuleTest.php
@@ -8,6 +8,10 @@ use OnPHP\Main\Util\Router\RouterTransparentRule;
 use OnPHP\Tests\TestEnvironment\ServerVarUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 	
+/**
+ * @group utils
+ * @group router
+ */
 class RouterTransparentRuleTest extends TestCase
 {
 	public function setUp(): void

--- a/tests/Main/Utils/SocketTest.php
+++ b/tests/Main/Utils/SocketTest.php
@@ -5,6 +5,10 @@ namespace OnPHP\Tests\Main\Utils;
 use OnPHP\Main\Util\IO\Socket;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group socket
+ */
 final class SocketTest extends TestCase
 {
 	public function testShutdown()

--- a/tests/Main/Utils/TypesUtilsTest.php
+++ b/tests/Main/Utils/TypesUtilsTest.php
@@ -5,6 +5,9 @@ namespace OnPHP\Tests\Main\Utils;
 use OnPHP\Main\Util\TypesUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ */
 final class TypesUtilsTest extends TestCase
 {
 	/**

--- a/tests/Main/Utils/UrlParamsUtilsTest.php
+++ b/tests/Main/Utils/UrlParamsUtilsTest.php
@@ -6,6 +6,9 @@ use OnPHP\Core\Exception\BaseException;
 use OnPHP\Main\Util\UrlParamsUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ */
 final class UrlParamsUtilsTest extends TestCase
 {
 	public function testAnyDeepLvl()

--- a/tests/Main/Utils/WebMoneyUtilsTest.php
+++ b/tests/Main/Utils/WebMoneyUtilsTest.php
@@ -4,6 +4,10 @@ namespace OnPHP\Tests\Main\Utils;
 use OnPHP\Main\Util\WebMoneyUtils;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group utils
+ * @group webmoney
+ */
 final class WebMoneyUtilsTest extends TestCase
 {
 	/**

--- a/tests/Main/ViewTest.php
+++ b/tests/Main/ViewTest.php
@@ -15,6 +15,10 @@ use OnPHP\Main\Flow\Model;
 use OnPHP\Main\UI\View\PhpViewResolver;
 use OnPHP\Tests\TestEnvironment\TestCase;
 
+/**
+ * @group main
+ * @group view
+ */
 final class ViewTest extends TestCase
 {
 	protected static $resolver;


### PR DESCRIPTION
../vendor/bin/phpunit --list-groups AllTests.php

Available test group(s):
 - amqp
 - cache
 - cookie
 - core
 - criteria
 - crypto
 - csv
 - curl
 - dao
 - date
 - db
 - filter
 - form
 - fs
 - http
 - ip
 - mail
 - main
 - math
 - memcached
 - monitoring
 - mysql
 - oql
 - osql
 - pinba
 - postgresql
 - proto
 - redis
 - router
 - socket
 - sqlite
 - text
 - utils
 - view
 - webmoney

Run test for only need groups:

../vendor/bin/phpunit --group db --verbose AllTests.php
../vendor/bin/phpunit --group db --verbose --exclude-group criteria,dao AllTests.php